### PR TITLE
Add numberOfAvailabilityZones param to Project constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ type ProjectArgs = {
     | EcsServiceOptions
   )[];
   enableSSMConnect?: pulumi.Input<boolean>;
+  numberOfAvailabilityZones?: number;
 };
 ```
 
@@ -101,6 +102,7 @@ type ProjectArgs = {
 | :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | services \*      |                                                                        Service list.                                                                         |
 | enableSSMConnect | Setup ec2 instance and SSM in order to connect to the database in the private subnet. Please refer to the [SSM Connect](#ssm-connect) section for more info. |
+| numberOfAvailabilityZones | Default is 2 which is recommended. If building a dev server, we can reduce to 1 availability zone to reduce hosting cost. |
 
 ```ts
 type DatabaseServiceOptions = {

--- a/src/components/project.ts
+++ b/src/components/project.ts
@@ -116,6 +116,7 @@ export type ProjectArgs = {
     | EcsServiceOptions
   )[];
   enableSSMConnect?: pulumi.Input<boolean>;
+  numberOfAvailabilityZones?: number;
 };
 
 export class MissingEcsCluster extends Error {
@@ -141,7 +142,7 @@ export class Project extends pulumi.ComponentResource {
     super('studion:Project', name, {}, opts);
     this.name = name;
 
-    this.vpc = this.createVpc();
+    this.vpc = this.createVpc(args.numberOfAvailabilityZones);
     this.createServices(args.services);
 
     if (args.enableSSMConnect) {
@@ -155,11 +156,11 @@ export class Project extends pulumi.ComponentResource {
     this.registerOutputs();
   }
 
-  private createVpc() {
+  private createVpc(numberOfAvailabilityZones: number = 2) {
     const vpc = new awsx.ec2.Vpc(
       `${this.name}-vpc`,
       {
-        numberOfAvailabilityZones: 2,
+        numberOfAvailabilityZones,
         enableDnsHostnames: true,
         enableDnsSupport: true,
         subnetSpecs: [


### PR DESCRIPTION
When creating the VPC, the default value is 2 which is recommended, but for different purposes we might want to change that number. For example, for dev server we can set it to 1 to keep the server cost down.