### PR TITLE
Add DB parameterGroupName argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ type DatabaseServiceOptions = {
   maxAllocatedStorage?: pulumi.Input<number>;
   instanceClass?: pulumi.Input<string>;
   enableMonitoring?: pulumi.Input<boolean>;
+  parameterGroupName?: pulumi.Input<string>;
   tags?: pulumi.Input<{
     [key: string]: pulumi.Input<string>;
   }>;
@@ -371,6 +372,7 @@ type DatabaseArgs = {
   maxAllocatedStorage?: pulumi.Input<number>;
   instanceClass?: pulumi.Input<string>;
   enableMonitoring?: pulumi.Input<boolean>;
+  parameterGroupName?: pulumi.Input<string>;
   tags?: pulumi.Input<{
     [key: string]: pulumi.Input<string>;
   }>;
@@ -413,6 +415,7 @@ type DatabaseReplicaArgs = {
   allocatedStorage?: pulumi.Input<number>;
   maxAllocatedStorage?: pulumi.Input<number>;
   instanceClass?: pulumi.Input<string>;
+  parameterGroupName?: pulumi.Input<string>;
   tags?: pulumi.Input<{
     [key: string]: pulumi.Input<string>;
   }>;

--- a/src/components/database-replica.ts
+++ b/src/components/database-replica.ts
@@ -46,6 +46,11 @@ export type DatabaseReplicaArgs = {
    */
   instanceClass?: pulumi.Input<string>;
   /**
+   * The name of custom aws.rds.ParameterGroup. Setting this param will apply custom
+   * DB parameters to this instance.
+   */
+  parameterGroupName?: pulumi.Input<string>;
+  /**
    * A map of tags to assign to the resource.
    */
   tags?: pulumi.Input<{
@@ -116,6 +121,7 @@ export class DatabaseReplica extends pulumi.ComponentResource {
         autoMinorVersionUpgrade: true,
         maintenanceWindow: 'Mon:07:00-Mon:07:30',
         replicateSourceDb: argsWithDefaults.replicateSourceDb,
+        parameterGroupName: argsWithDefaults.parameterGroupName,
         ...monitoringOptions,
         tags: { ...commonTags, ...argsWithDefaults.tags },
       },

--- a/src/components/database.ts
+++ b/src/components/database.ts
@@ -55,6 +55,11 @@ export type DatabaseArgs = {
    */
   enableMonitoring?: pulumi.Input<boolean>;
   /**
+   * The name of custom aws.rds.ParameterGroup. Setting this param will apply custom
+   * DB parameters to this instance.
+   */
+  parameterGroupName?: pulumi.Input<string>;
+  /**
    * A map of tags to assign to the resource.
    */
   tags?: pulumi.Input<{
@@ -230,6 +235,7 @@ export class Database extends pulumi.ComponentResource {
         finalSnapshotIdentifier: `${this.name}-final-snapshot-${stack}`,
         backupWindow: '06:00-06:30',
         backupRetentionPeriod: 14,
+        parameterGroupName: argsWithDefaults.parameterGroupName,
         ...monitoringOptions,
         tags: { ...commonTags, ...argsWithDefaults.tags },
       },


### PR DESCRIPTION
This argument allows us to set custom DB parameter group on a DB instance. This is useful in cases when we have to set custom DB params.