### PR TITLE
Docs: Document default Project component behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ $ pulumi up
 
 ### Project
 
-Project component makes it really easy to spin up project infrastructure,
+Project component makes it easy to spin up project infrastructure,
 hiding infrastructure complexity.
 <br>
 The component creates its own VPC used for resources within the project.
+<br><br>
+Services are created only if specified in the `services` list.
+<br>
+If `services` is an empty list, VPC is the only service created by default.
 
 ```ts
 new Project(name: string, args: ProjectArgs, opts?: pulumi.CustomResourceOptions);


### PR DESCRIPTION
This answers one of the first questions that came to mind while consuming this library:
What's the default `Project` component behavior?

This attempts to document the small part of the component's behavior to give developers the confidence to use it without reading the source code to be sure of how it behaves.