### PR TITLE
feat: use `17.2` as the default pg engine version

### DIFF
--- a/src/components/database-replica.ts
+++ b/src/components/database-replica.ts
@@ -51,7 +51,7 @@ export type DatabaseReplicaArgs = {
    */
   parameterGroupName?: pulumi.Input<string>;
   /**
-   * The DB engine version. Defaults to '15.5'.
+   * The DB engine version. Defaults to '17.2'.
    */
   engineVersion?: pulumi.Input<string>;
   /**
@@ -69,7 +69,7 @@ const defaults = {
   maxAllocatedStorage: 100,
   instanceClass: 'db.t4g.micro',
   enableMonitoring: false,
-  engineVersion: '15.5',
+  engineVersion: '17.2',
 };
 
 export class DatabaseReplica extends pulumi.ComponentResource {

--- a/src/components/database.ts
+++ b/src/components/database.ts
@@ -71,7 +71,7 @@ export type DatabaseArgs = {
    */
   snapshotIdentifier?: pulumi.Input<string>;
   /**
-   * The DB engine version. Defaults to '15.5'.
+   * The DB engine version. Defaults to '17.2'.
    */
   engineVersion?: pulumi.Input<string>;
   /**
@@ -91,7 +91,7 @@ const defaults = {
   instanceClass: 'db.t4g.micro',
   enableMonitoring: false,
   allowMajorVersionUpgrade: false,
-  engineVersion: '15.5',
+  engineVersion: '17.2',
 };
 
 export class Database extends pulumi.ComponentResource {


### PR DESCRIPTION
Since 15.5 is deprecated by AWS and results in `InvalidParameterCombination` error, default engine version option is updated to 17.2.