### PR TITLE
chore: update commit message for the `release-it` tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "access": "public"
   },
   "release-it": {
+    "git": {
+      "commitMessage": "chore: release ${version}"
+    },
     "github": {
       "release": true
     }


### PR DESCRIPTION
Configure commit message for the `release-it` tool to follow conventional commits convention.