### PR TITLE
ci: run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,9 @@ version: 2.1
 orbs:
   core: studion/core@3.0.0
   security: studion/security@2.0.0
-
+  aws-cli: circleci/aws-cli@5.2.0
+  node: circleci/node@7.1.0
+  
 change-filters: &change-filters
   branches:
     ignore: master
@@ -11,7 +13,23 @@ change-filters: &change-filters
 trunk-filters: &trunk-filters
   branches:
     only: master
-    
+
+commands:
+  setup-pulumi:
+    steps:
+      - run:
+          name: Install Pulumi
+          command: |
+            curl -sSL https://get.pulumi.com/ | bash -s
+            echo 'export PATH=${HOME}/.pulumi/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Login into Pulumi Cloud
+          command: pulumi login
+      - run:
+          name: Set default Pulumi Organization
+          command: pulumi org set-default extensionengine
+
 jobs:
   detect-leaks:
     executor: security/node
@@ -28,9 +46,23 @@ jobs:
     steps:
       - checkout
       - security/scan_dependencies:
-          pkg_manager: npm
           pkg_json_dir: <<parameters.pkg_json_dir>>
-
+  test-components:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - aws-cli/setup:
+          role_arn: ${AWS_ROLE_ARN}
+      - setup-pulumi
+      - node/install
+      - core/install_dependencies
+      - core/install_dependencies:
+          pkg_json_dir: './tests/web-server/infrastructure'
+      - core/run_script:
+          skip_install_dependencies: true
+          script: 'build && ${DEFAULT_PKG_MANAGER} test'
+      
 workflows:
   scan-and-test:
     jobs:
@@ -40,4 +72,6 @@ workflows:
           filters: *trunk-filters
       - security/detect_secrets_dir:
           name: detect-secrets
+          filters: *trunk-filters
+      - test-components:
           filters: *trunk-filters

--- a/tests/web-server/infrastructure/Pulumi.yaml
+++ b/tests/web-server/infrastructure/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: test-web-server
+name: icb-test-web-server
 description: A minimal AWS TypeScript Pulumi program
 runtime:
   name: nodejs


### PR DESCRIPTION
On every commit to the trunk run `tests` script from the `package.json`.

The reason to run tests only on the trunk is due to their execution time
which is currently close to 20 min, and that is consequence of
infrastructure provisioning and destroy in the before and after hooks.