### PR TITLE
feat: add OpenTelemetry collector container and config builders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@pulumi/awsx": "^2.21.0",
         "@pulumi/pulumi": "^3.146.0",
         "@pulumi/random": "^4.17.0",
-        "@upstash/pulumi": "^0.3.14"
+        "@upstash/pulumi": "^0.3.14",
+        "yaml": "^2.7.1"
       },
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.782.0",
@@ -10027,6 +10028,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@pulumi/awsx": "^2.21.0",
     "@pulumi/pulumi": "^3.146.0",
     "@pulumi/random": "^4.17.0",
-    "@upstash/pulumi": "^0.3.14"
+    "@upstash/pulumi": "^0.3.14",
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.782.0",

--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -44,8 +44,8 @@ export namespace EcsService {
   export type Container = {
     name: pulumi.Input<string>;
     image: pulumi.Input<string>;
-    portMappings: pulumi.Input<pulumi.Input<aws.ecs.PortMapping>[]>;
-    command?: pulumi.Input<string[]>;
+    portMappings?: pulumi.Input<pulumi.Input<aws.ecs.PortMapping>[]>;
+    command?: pulumi.Input<pulumi.Input<string>[]>;
     mountPoints?: PersistentStorageMountPoint[];
     environment?: pulumi.Input<aws.ecs.KeyValuePair[]>;
     secrets?: pulumi.Input<aws.ecs.Secret[]>;

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -1,3 +1,7 @@
 export { EcsService } from './components/ecs-service';
 export { WebServer } from './components/web-server';
 export { WebServerLoadBalancer } from './components/web-server/load-balancer';
+
+import { OtelCollectorConfigBuilder } from './otel/config';
+import { OtelCollector } from './otel/container';
+export const openTelemetry = { OtelCollector, OtelCollectorConfigBuilder };

--- a/src/v2/otel/config.ts
+++ b/src/v2/otel/config.ts
@@ -1,0 +1,312 @@
+import * as yaml from 'yaml';
+
+export namespace OtelCollectorConfigBuilder {
+  export type ReceiverType = 'otlp';
+  export type ReceiverProtocol = 'http' | 'rpc';
+  export type ReceiverConfig = {
+    protocols: {
+      [K in ReceiverProtocol]?: {
+        endpoint: string;
+      };
+    };
+  };
+  export type Receiver = {
+    [K in ReceiverType]?: ReceiverConfig;
+  };
+
+  export type ProcessorType = 'batch' | 'memory_limiter';
+  export type BatchProcessorConfig = {
+    send_batch_size: number;
+    send_batch_max_size: number;
+    timeout: string;
+  };
+  export type MemoryLimiterProcessorConfig = {
+    check_interval: string;
+    limit_percentage: number;
+    spike_limit_percentage: number;
+  };
+  export type Processor = {
+    batch?: BatchProcessorConfig;
+    memory_limiter?: MemoryLimiterProcessorConfig;
+  };
+
+  export type ExporterType = 'prometheusremotewrite' | 'awsxray' | 'debug';
+  export type PrometheusRemoteWriteExporterConfig = {
+    namespace: string;
+    endpoint: string;
+    auth?: {
+      authenticator: string;
+    };
+  };
+
+  export type AwsXRayExporterConfig = {
+    region: string;
+  };
+
+  export type DebugExportedConfig = {
+    verbosity: string;
+  };
+
+  export type Exporter = {
+    prometheusremotewrite?: PrometheusRemoteWriteExporterConfig;
+    awsxray?: AwsXRayExporterConfig;
+    debug?: DebugExportedConfig;
+  };
+
+  export type ExtensionType = 'sigv4auth' | 'health_check' | 'pprof';
+  export type SigV4AuthExtensionConfig = {
+    region: string;
+    service: string;
+  };
+
+  export type HealthCheckExtensionConfig = {
+    endpoint: string;
+  };
+
+  export type PprofExtensionConfig = {
+    endpoint: string;
+  };
+
+  export type Extension = {
+    sigv4auth?: SigV4AuthExtensionConfig;
+    health_check?: HealthCheckExtensionConfig;
+    pprof?: PprofExtensionConfig;
+  };
+
+  export type PipelineConfig = {
+    receivers: ReceiverType[];
+    processors: ProcessorType[];
+    exporters: ExporterType[];
+  };
+
+  export type TelemetryConfig = {
+    logs?: {
+      level: string;
+    };
+    metrics?: {
+      level: string;
+    };
+  };
+
+  export type Service = {
+    pipelines: {
+      metrics?: PipelineConfig;
+      traces?: PipelineConfig;
+    };
+    extensions?: ExtensionType[];
+    telemetry?: TelemetryConfig;
+  };
+}
+
+const OTLPReceiverProtocols = {
+  rpc: {
+    endpoint: '0.0.0.0:4317'
+  },
+  http: {
+    endpoint: '0.0.0.0:4318'
+  }
+};
+
+export class OtelCollectorConfigBuilder {
+  private readonly _receivers: OtelCollectorConfigBuilder.Receiver = {};
+  private readonly _processors: OtelCollectorConfigBuilder.Processor = {};
+  private readonly _exporters: OtelCollectorConfigBuilder.Exporter = {};
+  private readonly _extensions: OtelCollectorConfigBuilder.Extension = {};
+  private readonly _service: OtelCollectorConfigBuilder.Service = {
+    pipelines: {}
+  };
+
+  withOTLPReceiver(
+    protocols: OtelCollectorConfigBuilder.ReceiverProtocol[] = ['http']
+  ): this {
+    if (!protocols.length) {
+      throw new Error('At least one OTLP receiver protocol should be provided');
+    }
+
+    const protocolsConfig = protocols.reduce((all, current) => {
+      const protocolConfig = OTLPReceiverProtocols[current];
+      if (!protocolConfig) {
+        throw new Error(`OTLP receiver protocol ${current} is not supported`);
+      }
+
+      return { ...all, [current]: protocolConfig }
+    }, {});
+
+    this._receivers.otlp = { protocols: protocolsConfig };
+
+    return this;
+  }
+
+  withBatchProcessor(
+    size = 8192,
+    maxSize = 10000,
+    timeout = '5s'
+  ): this {
+    this._processors.batch = {
+      'send_batch_size': size,
+      'send_batch_max_size': maxSize,
+      timeout
+    };
+
+    return this;
+  }
+
+  withMemoryLimiterProcessor(
+    checkInterval = '5s',
+    limitPercentage = 80,
+    spikeLimitPercentage = 25
+  ): this {
+    this._processors.memory_limiter = {
+      check_interval: checkInterval,
+      limit_percentage: limitPercentage,
+      spike_limit_percentage: spikeLimitPercentage
+    };
+
+    return this;
+  }
+
+  withPrometheusRemoteWriteExporter(
+    namespace: string,
+    endpoint: string
+  ): this {
+    this._exporters.prometheusremotewrite = {
+      namespace,
+      endpoint,
+      auth: { authenticator: 'sigv4auth' }
+    };
+
+    return this;
+  }
+
+  withAWSXRayExporter(region: string): this {
+    this._exporters.awsxray = { region };
+
+    return this;
+  }
+
+  withSigV4AuthExtension(region: string): this {
+    this._extensions.sigv4auth = {
+      region,
+      service: 'aps'
+    };
+
+    return this;
+  }
+
+  withHealthCheckExtension(endpoint = '0.0.0.0:13133'): this {
+    this._extensions.health_check = { endpoint };
+
+    return this;
+  }
+
+  withPprofExtension(endpoint = '0.0.0.0:1777'): this {
+    this._extensions.pprof = { endpoint };
+
+    return this;
+  }
+
+  withAPS(namespace: string, endpoint: string, region: string): this {
+    this._exporters.prometheusremotewrite = {
+      endpoint,
+      namespace,
+      auth: {
+        authenticator: 'sigv4auth'
+      }
+    };
+
+    this._extensions.sigv4auth = {
+      region,
+      service: 'aps'
+    };
+
+    return this;
+  }
+
+  withDebug(verbosity: 'normal' | 'basic' | 'detailed' = 'detailed'): this {
+    this._exporters.debug = { verbosity };
+
+    return this;
+  }
+
+  withTelemetry(
+    logLevel: 'debug' | 'warn' | 'error' = 'error',
+    metricsVerbosity: 'basic' | 'normal' | 'detailed' = 'basic'
+  ): this {
+    this._service.telemetry = {
+      logs: { level: logLevel },
+      metrics: { level: metricsVerbosity }
+    };
+
+    return this;
+  }
+
+  withMetricsPipeline(
+    receivers: OtelCollectorConfigBuilder.ReceiverType[],
+    processors: OtelCollectorConfigBuilder.ProcessorType[],
+    exporters: OtelCollectorConfigBuilder.ExporterType[],
+  ): this {
+    this._service.pipelines.metrics = {
+      receivers,
+      processors,
+      exporters
+    };
+
+    return this;
+  }
+
+  withTracesPipeline(
+    receivers: OtelCollectorConfigBuilder.ReceiverType[],
+    processors: OtelCollectorConfigBuilder.ProcessorType[],
+    exporters: OtelCollectorConfigBuilder.ExporterType[],
+  ): this {
+    this._service.pipelines.traces = {
+      receivers,
+      processors,
+      exporters
+    };
+
+    return this;
+  }
+
+  build(): string {
+    this.validatePipelineComponents('metrics');
+    this.validatePipelineComponents('traces');
+
+    // FIX: Fix type inference
+    const extensions = Object.keys(
+      this._extensions
+    ) as OtelCollectorConfigBuilder.ExtensionType[];
+    if (extensions.length) {
+      this._service.extensions = extensions;
+    }
+
+    // TODO: Add schema validation (non-empty receivers, non-empty receiver protocols)
+    return yaml.stringify({
+      receivers: this._receivers,
+      processors: this._processors,
+      exporters: this._exporters,
+      extensions: this._extensions,
+      service: this._service
+    });
+  }
+
+  private validatePipelineComponents(pipelineType: 'metrics' | 'traces'): void {
+    this._service.pipelines[pipelineType]?.receivers.forEach(receiver => {
+      if (!this._receivers[receiver]) {
+        throw new Error(`Receiver '${receiver}' is used in ${pipelineType} pipeline but not defined`);
+      }
+    });
+
+    this._service.pipelines[pipelineType]?.processors.forEach(processor => {
+      if (!this._processors[processor]) {
+        throw new Error(`Processor '${processor}' is used in ${pipelineType} pipeline but not defined`);
+      }
+    });
+
+    this._service.pipelines[pipelineType]?.exporters.forEach(exporter => {
+      if (!this._exporters[exporter]) {
+        throw new Error(`Exporter '${exporter}' is used in ${pipelineType} pipeline but not defined`);
+      }
+    });
+  }
+}

--- a/src/v2/otel/config.ts
+++ b/src/v2/otel/config.ts
@@ -268,6 +268,30 @@ export class OtelCollectorConfigBuilder {
     return this;
   }
 
+  withDefault(
+    prometheusNamespace: string,
+    prometheusWriteEndpoint: string,
+    awsRegion: string
+  ): this {
+    return this.withOTLPReceiver(['http'])
+      .withBatchProcessor()
+      .withMemoryLimiterProcessor()
+      .withAPS(prometheusNamespace, prometheusWriteEndpoint, awsRegion)
+      .withAWSXRayExporter(awsRegion)
+      .withHealthCheckExtension()
+      .withMetricsPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['prometheusremotewrite']
+      )
+      .withTracesPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['awsxray']
+      )
+      .withTelemetry();
+  }
+
   build(): string {
     this.validatePipelineComponents('metrics');
     this.validatePipelineComponents('traces');

--- a/src/v2/otel/container.ts
+++ b/src/v2/otel/container.ts
@@ -1,0 +1,91 @@
+import * as pulumi from '@pulumi/pulumi';
+import { EcsService } from '../components/ecs-service';
+
+export namespace OtelCollector {
+  export type Args = {
+    containerName: pulumi.Input<string>;
+    serviceName: pulumi.Input<string>;
+    env: pulumi.Input<string>;
+    config: pulumi.Input<string>;
+    configVolumeName: pulumi.Input<string>;
+  };
+}
+
+export class OtelCollector {
+  container: EcsService.Container;
+  configContainer: EcsService.Container;
+
+  constructor({
+    containerName,
+    serviceName,
+    env,
+    config,
+    configVolumeName,
+  }: OtelCollector.Args) {
+    this.configContainer = this.createConfigContainer(
+      config,
+      configVolumeName
+    );
+
+    this.container = this.createContainer(
+      containerName,
+      configVolumeName,
+      serviceName,
+      env
+    );
+  }
+
+  get containers(): EcsService.Container[] {
+    return [this.configContainer, this.container];
+  }
+
+  private createContainer(
+    containerName: pulumi.Input<string>,
+    configVolumeName: pulumi.Input<string>,
+    serviceName: pulumi.Input<string>,
+    env: pulumi.Input<string>
+  ): EcsService.Container {
+    return {
+      name: containerName,
+      image: 'otel/opentelemetry-collector-contrib:latest',
+      portMappings: [
+        { containerPort: 4317, hostPort: 4317, protocol: 'tcp' },
+        { containerPort: 4318, hostPort: 4318, protocol: 'tcp' },
+        // TODO: Expose 8888 for collector telemetry
+        { containerPort: 13133, hostPort: 13133, protocol: 'tcp' },
+      ],
+      mountPoints: [{
+        sourceVolume: configVolumeName,
+        containerPath: '/etc/otelcol-contrib',
+        readOnly: true
+      }],
+      dependsOn: [{
+        containerName: this.configContainer.name,
+        condition: 'COMPLETE'
+      }],
+      environment: [
+        { name: 'OTEL_RESOURCE_ATTRIBUTES', value: `service.name=${serviceName},env=${env}` },
+        { name: 'OTEL_LOG_LEVEL', value: 'debug' },
+        { name: 'OTELCOL_CONTRIB_DEBUG', value: '1' }
+      ]
+    };
+  }
+
+  private createConfigContainer(
+    config: pulumi.Input<string>,
+    volume: pulumi.Input<string>
+  ): EcsService.Container {
+    return {
+      name: 'otel-config-writer',
+      image: 'amazonlinux:latest',
+      essential: false,
+      command: [
+        'sh', '-c',
+        pulumi.interpolate`echo '${config}' > /etc/otelcol-contrib/config.yaml`],
+      mountPoints: [{
+        sourceVolume: volume,
+        containerPath: '/etc/otelcol-contrib',
+      }]
+    }
+  }
+}

--- a/tests/otel/index.test.ts
+++ b/tests/otel/index.test.ts
@@ -1,0 +1,397 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import * as yaml from 'yaml';
+import { OtelCollectorConfigBuilder } from '../../src/v2/otel/config';
+import { testOtelCollectorConfigBuilderValidation } from './validation.test';
+
+const awsRegion = 'us-west-2';
+const prometheusNamespace = 'test-namespace';
+const prometheusWriteEndpoint = 'https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345/api/v1/remote_write';
+
+describe('OtelCollectorConfigBuilder', () => {
+  it(
+    'should generate minimal configuration with OTLP receiver and debug exporter',
+    () => {
+      const yamlOutput = new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withDebug()
+        .build();
+
+      const result = yaml.parse(yamlOutput);
+
+      const expected = {
+        receivers: {
+          otlp: {
+            protocols: {
+              http: { endpoint: '0.0.0.0:4318' }
+            }
+          }
+        },
+        processors: {},
+        exporters: {
+          debug: { verbosity: 'detailed' }
+        },
+        extensions: {},
+        service: { pipelines: {} }
+      };
+
+      assert.deepStrictEqual(result, expected);
+    }
+  );
+
+  it('should configure batch processor', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withBatchProcessor()
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+
+    const expected = {
+      receivers: {},
+      processors: {
+        batch: {
+          send_batch_size: 8192,
+          send_batch_max_size: 10000,
+          timeout: '5s'
+        }
+      },
+      exporters: {},
+      extensions: {},
+      service: { pipelines: {} }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure memory limiter processor', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withMemoryLimiterProcessor()
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+
+    const expected = {
+      receivers: {},
+      processors: {
+        memory_limiter: {
+          check_interval: '5s',
+          limit_percentage: 80,
+          spike_limit_percentage: 25
+        }
+      },
+      exporters: {},
+      extensions: {},
+      service: { pipelines: {} }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('withBatchProcessor should use provided parameters', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withBatchProcessor(5000, 8000, '10s')
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    assert.deepStrictEqual(result.processors.batch, {
+      send_batch_size: 5000,
+      send_batch_max_size: 8000,
+      timeout: '10s'
+    });
+  });
+
+  it('withMemoryLimiterProcessor should use provided parameters', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withMemoryLimiterProcessor('3s', 70, 15)
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    assert.deepStrictEqual(result.processors.memory_limiter, {
+      check_interval: '3s',
+      limit_percentage: 70,
+      spike_limit_percentage: 15
+    });
+  });
+
+  it('should configure Amazon Prometheus Service (APS) exporter', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withAPS(prometheusNamespace, prometheusWriteEndpoint, awsRegion)
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {},
+      processors: {},
+      exporters: {
+        prometheusremotewrite: {
+          namespace: prometheusNamespace,
+          endpoint: prometheusWriteEndpoint,
+          auth: { authenticator: 'sigv4auth' }
+        }
+      },
+      extensions: {
+        sigv4auth: {
+          region: awsRegion,
+          service: 'aps'
+        }
+      },
+      service: {
+        extensions: ['sigv4auth'],
+        pipelines: {}
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure AWS X-Ray exporter', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withAWSXRayExporter(awsRegion)
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {},
+      processors: {},
+      exporters: {
+        awsxray: { region: awsRegion }
+      },
+      extensions: {},
+      service: { pipelines: {} }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure SigV4Auth extension', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withSigV4AuthExtension(awsRegion)
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {},
+      processors: {},
+      exporters: {},
+      extensions: {
+        sigv4auth: {
+          region: awsRegion,
+          service: 'aps'
+        }
+      },
+      service: {
+        extensions: ['sigv4auth'],
+        pipelines: {}
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure health check extension', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withHealthCheckExtension()
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {},
+      processors: {},
+      exporters: {},
+      extensions: {
+        health_check: { endpoint: '0.0.0.0:13133' }
+      },
+      service: {
+        extensions: ['health_check'],
+        pipelines: {}
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure pprof extension', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withPprofExtension()
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {},
+      processors: {},
+      exporters: {},
+      extensions: {
+        pprof: { endpoint: '0.0.0.0:1777' }
+      },
+      service: {
+        extensions: ['pprof'],
+        pipelines: {}
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('should configure pipelines', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withBatchProcessor()
+      .withMemoryLimiterProcessor()
+      .withAWSXRayExporter(awsRegion)
+      .withDebug()
+      .withMetricsPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['debug']
+      )
+      .withTracesPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['awsxray', 'debug']
+      )
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    const expected = {
+      receivers: {
+        otlp: {
+          protocols: {
+            http: { endpoint: '0.0.0.0:4318' }
+          }
+        }
+      },
+      processors: {
+        batch: {
+          send_batch_size: 8192,
+          send_batch_max_size: 10000,
+          timeout: '5s'
+        },
+        memory_limiter: {
+          check_interval: '5s',
+          limit_percentage: 80,
+          spike_limit_percentage: 25
+        }
+      },
+      exporters: {
+        awsxray: { region: awsRegion },
+        debug: { verbosity: 'detailed' }
+      },
+      extensions: {},
+      service: {
+        pipelines: {
+          metrics: {
+            receivers: ['otlp'],
+            processors: ['memory_limiter', 'batch'],
+            exporters: ['debug']
+          },
+          traces: {
+            receivers: ['otlp'],
+            processors: ['memory_limiter', 'batch'],
+            exporters: ['awsxray', 'debug']
+          }
+        }
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  it('withDebug should use provided verbosity', () => {
+    const verbosity = 'basic';
+
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withDebug(verbosity)
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+    assert.strictEqual(result.exporters.debug.verbosity, verbosity);
+  });
+
+  it('should generate complete configuration', () => {
+    const yamlOutput = new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withBatchProcessor()
+      .withMemoryLimiterProcessor()
+      .withAPS(prometheusNamespace, prometheusWriteEndpoint, awsRegion)
+      .withAWSXRayExporter(awsRegion)
+      .withDebug()
+      .withTelemetry()
+      .withHealthCheckExtension()
+      .withPprofExtension()
+      .withMetricsPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['prometheusremotewrite', 'debug']
+      )
+      .withTracesPipeline(
+        ['otlp'],
+        ['memory_limiter', 'batch'],
+        ['awsxray', 'debug']
+      )
+      .build();
+
+    const result = yaml.parse(yamlOutput);
+
+    const expected = {
+      receivers: {
+        otlp: {
+          protocols: {
+            http: { endpoint: '0.0.0.0:4318' }
+          }
+        }
+      },
+      processors: {
+        batch: {
+          send_batch_size: 8192,
+          send_batch_max_size: 10000,
+          timeout: '5s'
+        },
+        memory_limiter: {
+          check_interval: '5s',
+          limit_percentage: 80,
+          spike_limit_percentage: 25
+        }
+      },
+      exporters: {
+        prometheusremotewrite: {
+          namespace: prometheusNamespace,
+          endpoint: prometheusWriteEndpoint,
+          auth: { authenticator: 'sigv4auth' }
+        },
+        awsxray: { region: awsRegion },
+        debug: { verbosity: 'detailed' }
+      },
+      extensions: {
+        sigv4auth: {
+          region: awsRegion,
+          service: 'aps'
+        },
+        health_check: { endpoint: '0.0.0.0:13133' },
+        pprof: { endpoint: '0.0.0.0:1777' }
+      },
+      service: {
+        extensions: ['sigv4auth', 'health_check', 'pprof'],
+        pipelines: {
+          metrics: {
+            receivers: ['otlp'],
+            processors: ['memory_limiter', 'batch'],
+            exporters: ['prometheusremotewrite', 'debug']
+          },
+          traces: {
+            receivers: ['otlp'],
+            processors: ['memory_limiter', 'batch'],
+            exporters: ['awsxray', 'debug']
+          }
+        },
+        telemetry: {
+          logs: { level: 'error' },
+          metrics: { level: 'basic' }
+        }
+      }
+    };
+
+    assert.deepStrictEqual(result, expected);
+  });
+
+  describe('validation', testOtelCollectorConfigBuilderValidation);
+});

--- a/tests/otel/validation.test.ts
+++ b/tests/otel/validation.test.ts
@@ -1,0 +1,100 @@
+import { it } from 'node:test';
+import * as assert from 'node:assert';
+import { OtelCollectorConfigBuilder } from '../../src/v2/otel/config';
+
+export function testOtelCollectorConfigBuilderValidation() {
+  it('should throw error when no OTLP receiver protocols are provided', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withOTLPReceiver([])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: 'At least one OTLP receiver protocol should be provided'
+    });
+  });
+
+  it('should throw error when unsupported OTLP receiver protocol is provided', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      // @ts-expect-error - Passing invalid protocol to test runtime error
+      .withOTLPReceiver(['invalid'])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: 'OTLP receiver protocol invalid is not supported'
+    });
+  });
+
+  it('should throw error when metrics pipeline references undefined receiver', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withMetricsPipeline(['otlp'], [], [])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Receiver 'otlp' is used in metrics pipeline but not defined"
+    });
+  });
+
+  it('should throw error when metrics pipeline references undefined processor', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withMetricsPipeline(['otlp'], ['batch'], [])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Processor 'batch' is used in metrics pipeline but not defined"
+    });
+  });
+
+  it('should throw error when metrics pipeline references undefined exporter', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withBatchProcessor()
+      .withMetricsPipeline(['otlp'], ['batch'], ['debug'])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Exporter 'debug' is used in metrics pipeline but not defined"
+    });
+  });
+
+  it('should throw error when traces pipeline references undefined receiver', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withTracesPipeline(['otlp'], [], [])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Receiver 'otlp' is used in traces pipeline but not defined"
+    });
+  });
+
+  it('should throw error when traces pipeline references undefined processor', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withTracesPipeline(['otlp'], ['memory_limiter'], [])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Processor 'memory_limiter' is used in traces pipeline but not defined"
+    });
+  });
+
+  it('should throw error when traces pipeline references undefined exporter', () => {
+    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withMemoryLimiterProcessor()
+      .withTracesPipeline(['otlp'], ['memory_limiter'], ['awsxray'])
+      .build();
+
+    assert.throws(createInvalidConfig, {
+      name: 'Error',
+      message: "Exporter 'awsxray' is used in traces pipeline but not defined"
+    });
+  });
+}


### PR DESCRIPTION
This PR:
- adds OpenTelemetry collector config builder (`OtelCollectorConfigBuilder`)
- `OtelCollector` class that creates ECS task container definitions for collector configuration container and collector container
- config builder API example can be found in the test suite.