### PR TITLE
feat: enable APS OpenTelemetry exporter

### DIFF
--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -1,7 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
-import { Policy } from '@pulumi/aws/iam/policy';
 import { CustomSize, Size } from '../../../types/size';
 import { PredefinedSize, commonTags } from '../../../constants';
 import { assumeRolePolicy } from './policies';
@@ -70,6 +69,8 @@ export namespace EcsService {
     targetGroupArn: aws.lb.TargetGroup['arn'];
   };
 
+  export type RoleInlinePolicy = aws.types.input.iam.RoleInlinePolicy;
+
   export type Args = {
     cluster: pulumi.Input<aws.ecs.Cluster>;
     vpc: pulumi.Input<awsx.ec2.Vpc>;
@@ -98,8 +99,12 @@ export namespace EcsService {
      */
     securityGroup?: pulumi.Input<aws.ec2.SecurityGroup>;
     assignPublicIp?: pulumi.Input<boolean>;
-    taskExecutionRoleInlinePolicies?: pulumi.Input<pulumi.Input<Policy>[]>;
-    taskRoleInlinePolicies?: pulumi.Input<pulumi.Input<Policy>[]>;
+    taskExecutionRoleInlinePolicies?: pulumi.Input<
+      pulumi.Input<RoleInlinePolicy>[]
+    >;
+    taskRoleInlinePolicies?: pulumi.Input<
+      pulumi.Input<RoleInlinePolicy>[]
+    >;
     /**
      * Registers tasks with AWS Cloud Map and creates discoverable DNS entries for each task.
      * Simplifies service-to-service communication by enabling service finding based on DNS records such as `http://serviceName.local`.
@@ -332,7 +337,7 @@ export class EcsService extends pulumi.ComponentResource {
   }
 
   private createTaskExecutionRole(
-    inlinePolicies: pulumi.Output<Policy[]>
+    inlinePolicies: pulumi.Output<EcsService.RoleInlinePolicy[]>
   ): aws.iam.Role {
     const secretManagerSecretsInlinePolicy = {
       name: `${this.name}-secret-manager-access`,
@@ -371,7 +376,7 @@ export class EcsService extends pulumi.ComponentResource {
   }
 
   private createTaskRole(
-    inlinePolicies: pulumi.Output<Policy[]>
+    inlinePolicies: pulumi.Output<EcsService.RoleInlinePolicy[]>
   ): aws.iam.Role {
     const execCmdInlinePolicy = {
       name: `${this.name}-exec`,

--- a/src/v2/components/web-server/builder.ts
+++ b/src/v2/components/web-server/builder.ts
@@ -104,8 +104,12 @@ export class WebServerBuilder {
     return this;
   }
 
-  public withCustomHealthCheckPath(path: WebServer.Args['healthCheckPath']) {
+  public withCustomHealthCheckPath(
+    path: WebServer.Args['healthCheckPath']
+  ): this {
     this._healthCheckPath = path;
+
+    return this;
   }
 
   public build(opts: pulumi.ComponentResourceOptions = {}): WebServer {

--- a/src/v2/components/web-server/builder.ts
+++ b/src/v2/components/web-server/builder.ts
@@ -27,7 +27,7 @@ export class WebServerBuilder {
   private _domain?: pulumi.Input<string>;
   private _hostedZoneId?: pulumi.Input<string>;
   private _healthCheckPath?: pulumi.Input<string>;
-  private _otelCollectorConfig?: pulumi.Input<OtelCollector.Config>;
+  private _otelCollector?: pulumi.Input<OtelCollector>;
   private _initContainers: pulumi.Input<WebServer.InitContainer>[] = [];
   private _sidecarContainers: pulumi.Input<WebServer.SidecarContainer>[] = [];
   private _volumes: EcsService.PersistentStorageVolume[] = [];
@@ -98,8 +98,8 @@ export class WebServerBuilder {
     return this;
   }
 
-  public withOtelCollector(config: pulumi.Input<OtelCollector.Config>): this {
-    this._otelCollectorConfig = config;
+  public withOtelCollector(collector: OtelCollector): this {
+    this._otelCollector = collector;
 
     return this;
   }
@@ -128,7 +128,7 @@ export class WebServerBuilder {
       domain: this._domain,
       hostedZoneId: this._hostedZoneId,
       healthCheckPath: this._healthCheckPath,
-      otelCollectorConfig: this._otelCollectorConfig,
+      otelCollector: this._otelCollector,
       initContainers: this._initContainers,
       sidecarContainers: this._sidecarContainers
     }, opts)

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -167,6 +167,24 @@ export class WebServer extends pulumi.ComponentResource {
     });
   }
 
+  private getTaskRoleInlinePolicies(
+    args: WebServer.Args
+  ): pulumi.Output<EcsService.RoleInlinePolicy[]> {
+    return pulumi.all([
+      pulumi.output(args.taskExecutionRoleInlinePolicies),
+      args.otelCollector
+    ]).apply(([passedTaskRoleInlinePolicies, otelCollector]) => {
+      const inlinePolicies = [];
+      if (passedTaskRoleInlinePolicies) inlinePolicies.push(...passedTaskRoleInlinePolicies);
+      if (otelCollector && otelCollector.taskRoleInlinePolicies) {
+        inlinePolicies.push(...otelCollector.taskRoleInlinePolicies);
+      }
+
+      return inlinePolicies;
+    });
+  }
+
+
   private createEcsConfig(args: WebServer.Args): WebServer.EcsConfig {
     return {
       vpc: args.vpc,
@@ -175,7 +193,7 @@ export class WebServer extends pulumi.ComponentResource {
       autoscaling: args.autoscaling,
       size: args.size,
       taskExecutionRoleInlinePolicies: args.taskExecutionRoleInlinePolicies,
-      taskRoleInlinePolicies: args.taskRoleInlinePolicies,
+      taskRoleInlinePolicies: this.getTaskRoleInlinePolicies(args),
       tags: args.tags,
     };
   }

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -3,6 +3,6 @@ export { WebServer } from './components/web-server';
 export { WebServerBuilder } from './components/web-server/builder';
 export { WebServerLoadBalancer } from './components/web-server/load-balancer';
 
-import { OtelCollectorConfigBuilder } from './otel/config';
+import { OtelCollectorBuilder } from './otel/builder';
 import { OtelCollector } from './otel';
-export const openTelemetry = { OtelCollector, OtelCollectorConfigBuilder };
+export const openTelemetry = { OtelCollector, OtelCollectorBuilder };

--- a/src/v2/otel/batch-processor.ts
+++ b/src/v2/otel/batch-processor.ts
@@ -1,0 +1,13 @@
+export namespace BatchProcessor {
+  export type Config = {
+    send_batch_size: number;
+    send_batch_max_size: number;
+    timeout: string;
+  };
+}
+
+export const defaults = {
+  size: 8192,
+  maxSize: 10000,
+  timeout: '5s'
+};

--- a/src/v2/otel/builder.ts
+++ b/src/v2/otel/builder.ts
@@ -1,0 +1,199 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as aws from '@pulumi/aws';
+import * as batchProcessor from './batch-processor';
+import * as memoryLimiterProcessor from './memory-limiter-processor';
+import { OtelCollector } from '.';
+import { OtelCollectorConfigBuilder } from './config';
+import { EcsService } from '../components/ecs-service';
+import { OTLPReceiver } from './otlp-receiver';
+
+export class OtelCollectorBuilder {
+  private readonly _serviceName: pulumi.Output<string>;
+  private readonly _env: pulumi.Output<string>;
+  private readonly _configBuilder: OtelCollectorConfigBuilder;
+  private _taskRoleInlinePolicies: pulumi.Output<EcsService.RoleInlinePolicy>[] = [];
+
+  constructor(
+    serviceName: pulumi.Input<string>,
+    env: pulumi.Input<string>
+  ) {
+    this._serviceName = pulumi.output(serviceName);
+    this._env = pulumi.output(env);
+    this._configBuilder = new OtelCollectorConfigBuilder();
+  }
+
+  withOTLPReceiver(
+    protocols: OTLPReceiver.Protocol[] = ['http']
+  ): this {
+    this._configBuilder.withOTLPReceiver(protocols);
+
+    return this;
+  }
+
+  withBatchProcessor(
+    size = batchProcessor.defaults.size,
+    maxSize = batchProcessor.defaults.maxSize,
+    timeout = batchProcessor.defaults.timeout
+  ): this {
+    this._configBuilder.withBatchProcessor(size, maxSize, timeout);
+
+    return this;
+  }
+
+  withMemoryLimiterProcessor(
+    checkInterval = memoryLimiterProcessor.defaults.checkInterval,
+    limitPercentage = memoryLimiterProcessor.defaults.limitPercentage,
+    spikeLimitPercentage = memoryLimiterProcessor.defaults.spikeLimitPercentage
+  ): this {
+    this._configBuilder.withMemoryLimiterProcessor(
+      checkInterval,
+      limitPercentage,
+      spikeLimitPercentage
+    );
+
+    return this;
+  }
+
+  withAWSXRayExporter(region: string): this {
+    this._configBuilder.withAWSXRayExporter(region);
+    this.createAWSXRayPolicy();
+
+    return this;
+  }
+
+  withHealthCheckExtension(endpoint = '0.0.0.0:13133'): this {
+    this._configBuilder.withHealthCheckExtension(endpoint);
+
+    return this;
+  }
+
+  withPprofExtension(endpoint = '0.0.0.0:1777'): this {
+    this._configBuilder.withPprofExtension(endpoint);
+
+    return this;
+  }
+
+  withAPS(
+    namespace: pulumi.Input<string>,
+    workspace: aws.amp.Workspace,
+    region: string
+  ): this {
+    this._configBuilder.withAPS(
+      pulumi.output(namespace),
+      pulumi.interpolate`${workspace.prometheusEndpoint}api/v1/remote_write`,
+      region
+    );
+    this.createAPSInlinePolicy(workspace);
+
+    return this;
+  }
+
+  withDebug(verbosity: 'normal' | 'basic' | 'detailed' = 'detailed'): this {
+    this._configBuilder.withDebug(verbosity);
+
+    return this;
+  }
+
+  withTelemetry(
+    logLevel: 'debug' | 'warn' | 'error' = 'error',
+    metricsVerbosity: 'basic' | 'normal' | 'detailed' = 'basic'
+  ): this {
+    this._configBuilder.withTelemetry(logLevel, metricsVerbosity);
+
+    return this;
+  }
+
+  withMetricsPipeline(
+    receivers: OtelCollector.ReceiverType[],
+    processors: OtelCollector.ProcessorType[],
+    exporters: OtelCollector.ExporterType[],
+  ): this {
+    this._configBuilder.withMetricsPipeline(
+      receivers,
+      processors,
+      exporters
+    );
+
+    return this;
+  }
+
+  withTracesPipeline(
+    receivers: OtelCollector.ReceiverType[],
+    processors: OtelCollector.ProcessorType[],
+    exporters: OtelCollector.ExporterType[],
+  ): this {
+    this._configBuilder.withTracesPipeline(
+      receivers,
+      processors,
+      exporters
+    );
+
+    return this;
+  }
+
+  withDefault(
+    prometheusNamespace: pulumi.Input<string>,
+    prometheusWorkspace: aws.amp.Workspace,
+    awsRegion: string
+  ): this {
+    this._configBuilder.withDefault(
+      pulumi.output(prometheusNamespace),
+      pulumi.interpolate`${prometheusWorkspace.prometheusEndpoint}api/v1/remote_write`,
+      awsRegion
+    );
+    this.createAPSInlinePolicy(prometheusWorkspace);
+
+    return this;
+  }
+
+  build(): OtelCollector {
+    return new OtelCollector(
+      this._serviceName,
+      this._env,
+      this._configBuilder.build(),
+      { taskRoleInlinePolicies: this._taskRoleInlinePolicies }
+    );
+  }
+
+  private createAPSInlinePolicy(workspace: aws.amp.Workspace): void {
+    const policy: pulumi.Output<EcsService.RoleInlinePolicy> = pulumi.all(([
+      this._serviceName,
+      workspace.arn
+    ])).apply(([serviceName, workspaceArn]) => ({
+      name: `${serviceName}-task-role-aps-write`,
+      policy: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [{
+          Effect: 'Allow',
+          Action: ['aps:RemoteWrite'],
+          Resource: workspaceArn,
+        }],
+      }),
+    }));
+
+    this._taskRoleInlinePolicies.push(policy);
+  }
+
+  private createAWSXRayPolicy() {
+    const policy: pulumi.Output<EcsService.RoleInlinePolicy> = this._serviceName
+      .apply(serviceName => ({
+        name: `${serviceName}-task-role-xray`,
+        policy: JSON.stringify({
+          Version: '2012-10-17',
+          Statement: [{
+            Effect: 'Allow',
+            Action: [
+              'xray:PutTraceSegments',
+              'xray:PutTelemetryRecords',
+              'xray:GetSamplingRules',
+              'xray:GetSamplingTargets',
+              'xray:GetSamplingStatisticSummaries',
+            ],
+            Resource: '*',
+          }],
+        }),
+      }));
+
+    this._taskRoleInlinePolicies.push(policy);
+  }
+}

--- a/src/v2/otel/config.ts
+++ b/src/v2/otel/config.ts
@@ -1,13 +1,6 @@
-import type { OtelCollector } from './index';
-
-const OTLPReceiverProtocols = {
-  grpc: {
-    endpoint: '0.0.0.0:4317'
-  },
-  http: {
-    endpoint: '0.0.0.0:4318'
-  }
-};
+import * as pulumi from '@pulumi/pulumi';
+import { OTLPReceiver, Protocol } from './otlp-receiver';
+import type { OtelCollector } from '.';
 
 export class OtelCollectorConfigBuilder {
   private readonly _receivers: OtelCollector.Receiver = {};
@@ -19,14 +12,14 @@ export class OtelCollectorConfigBuilder {
   };
 
   withOTLPReceiver(
-    protocols: OtelCollector.ReceiverProtocol[] = ['http']
+    protocols: OTLPReceiver.Protocol[] = ['http']
   ): this {
     if (!protocols.length) {
       throw new Error('At least one OTLP receiver protocol should be provided');
     }
 
     const protocolsConfig = protocols.reduce((all, current) => {
-      const protocolConfig = OTLPReceiverProtocols[current];
+      const protocolConfig = Protocol[current];
       if (!protocolConfig) {
         throw new Error(`OTLP receiver protocol ${current} is not supported`);
       }

--- a/src/v2/otel/config.ts
+++ b/src/v2/otel/config.ts
@@ -60,30 +60,8 @@ export class OtelCollectorConfigBuilder {
     return this;
   }
 
-  withPrometheusRemoteWriteExporter(
-    namespace: string,
-    endpoint: string
-  ): this {
-    this._exporters.prometheusremotewrite = {
-      namespace,
-      endpoint,
-      auth: { authenticator: 'sigv4auth' }
-    };
-
-    return this;
-  }
-
   withAWSXRayExporter(region: string): this {
     this._exporters.awsxray = { region };
-
-    return this;
-  }
-
-  withSigV4AuthExtension(region: string): this {
-    this._extensions.sigv4auth = {
-      region,
-      service: 'aps'
-    };
 
     return this;
   }
@@ -100,7 +78,11 @@ export class OtelCollectorConfigBuilder {
     return this;
   }
 
-  withAPS(namespace: string, endpoint: string, region: string): this {
+  withAPS(
+    namespace: pulumi.Input<string>,
+    endpoint: pulumi.Input<string>,
+    region: string
+  ): this {
     this._exporters.prometheusremotewrite = {
       endpoint,
       namespace,
@@ -164,8 +146,8 @@ export class OtelCollectorConfigBuilder {
   }
 
   withDefault(
-    prometheusNamespace: string,
-    prometheusWriteEndpoint: string,
+    prometheusNamespace: pulumi.Input<string>,
+    prometheusWriteEndpoint: pulumi.Input<string>,
     awsRegion: string
   ): this {
     return this.withOTLPReceiver(['http'])

--- a/src/v2/otel/index.ts
+++ b/src/v2/otel/index.ts
@@ -89,6 +89,9 @@ export namespace OtelCollector {
   export type Opts = {
     containerName?: pulumi.Input<string>;
     configVolumeName?: pulumi.Input<string>;
+    taskRoleInlinePolicies?: pulumi.Input<
+      pulumi.Input<EcsService.RoleInlinePolicy>[]
+    >;
   };
 }
 
@@ -97,6 +100,7 @@ export class OtelCollector {
   configVolume: pulumi.Output<string>;
   container: pulumi.Output<EcsService.Container>;
   configContainer: EcsService.Container;
+  taskRoleInlinePolicies: OtelCollector.Opts['taskRoleInlinePolicies'];
 
   constructor(
     serviceName: pulumi.Input<string>,
@@ -109,6 +113,7 @@ export class OtelCollector {
     const configVolumeName = opts.configVolumeName ||
       'otel-collector-config-volume';
     this.configVolume = pulumi.output(configVolumeName);
+    this.taskRoleInlinePolicies = opts.taskRoleInlinePolicies || [];
 
     this.config = pulumi.output(config);
     this.configContainer = this.createConfigContainer(

--- a/src/v2/otel/index.ts
+++ b/src/v2/otel/index.ts
@@ -2,45 +2,22 @@ import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws';
 import * as yaml from 'yaml';
 import { EcsService } from '../components/ecs-service';
+import { OTLPReceiver } from './otlp-receiver';
+import { BatchProcessor } from './batch-processor';
+import { MemoryLimiterProcessor } from './memory-limiter-processor';
+import { PrometheusRemoteWriteExporter } from './prometheus-remote-write-exporter';
 
 export namespace OtelCollector {
-  export type ReceiverType = 'otlp';
-  export type ReceiverProtocol = 'http' | 'grpc';
-  export type ReceiverConfig = {
-    protocols: {
-      [K in ReceiverProtocol]?: {
-        endpoint: string;
-      };
-    };
-  };
   export type Receiver = {
-    [K in ReceiverType]?: ReceiverConfig;
+    otlp?: OTLPReceiver.Config;
   };
+  export type ReceiverType = keyof Receiver;
 
-  export type ProcessorType = 'batch' | 'memory_limiter';
-  export type BatchProcessorConfig = {
-    send_batch_size: number;
-    send_batch_max_size: number;
-    timeout: string;
-  };
-  export type MemoryLimiterProcessorConfig = {
-    check_interval: string;
-    limit_percentage: number;
-    spike_limit_percentage: number;
-  };
   export type Processor = {
-    batch?: BatchProcessorConfig;
-    memory_limiter?: MemoryLimiterProcessorConfig;
+    batch?: BatchProcessor.Config;
+    memory_limiter?: MemoryLimiterProcessor.Config;
   };
-
-  export type ExporterType = 'prometheusremotewrite' | 'awsxray' | 'debug';
-  export type PrometheusRemoteWriteExporterConfig = {
-    namespace: string;
-    endpoint: string;
-    auth?: {
-      authenticator: string;
-    };
-  };
+  export type ProcessorType = keyof Processor;
 
   export type AwsXRayExporterConfig = {
     region: string;
@@ -51,12 +28,12 @@ export namespace OtelCollector {
   };
 
   export type Exporter = {
-    prometheusremotewrite?: PrometheusRemoteWriteExporterConfig;
+    prometheusremotewrite?: PrometheusRemoteWriteExporter.Config;
     awsxray?: AwsXRayExporterConfig;
     debug?: DebugExportedConfig;
   };
+  export type ExporterType = keyof Exporter;
 
-  export type ExtensionType = 'sigv4auth' | 'health_check' | 'pprof';
   export type SigV4AuthExtensionConfig = {
     region: string;
     service: string;
@@ -75,6 +52,7 @@ export namespace OtelCollector {
     health_check?: HealthCheckExtensionConfig;
     pprof?: PprofExtensionConfig;
   };
+  export type ExtensionType = keyof Extension;
 
   export type PipelineConfig = {
     receivers: ReceiverType[];

--- a/src/v2/otel/memory-limiter-processor.ts
+++ b/src/v2/otel/memory-limiter-processor.ts
@@ -1,0 +1,13 @@
+export namespace MemoryLimiterProcessor {
+  export type Config = {
+    check_interval: string;
+    limit_percentage: number;
+    spike_limit_percentage: number;
+  };
+}
+
+export const defaults = {
+  checkInterval: '1s',
+  limitPercentage: 80,
+  spikeLimitPercentage: 15
+};

--- a/src/v2/otel/otlp-receiver.ts
+++ b/src/v2/otel/otlp-receiver.ts
@@ -1,0 +1,20 @@
+export namespace OTLPReceiver {
+  export type Protocol = 'http' | 'grpc';
+  export type Config = {
+    protocols: {
+      [K in Protocol]?: {
+        endpoint: string;
+      };
+    };
+  };
+}
+
+export const Protocol = {
+  grpc: {
+    endpoint: '0.0.0.0:4317'
+  },
+  http: {
+    endpoint: '0.0.0.0:4318'
+  }
+};
+

--- a/src/v2/otel/prometheus-remote-write-exporter.ts
+++ b/src/v2/otel/prometheus-remote-write-exporter.ts
@@ -1,0 +1,12 @@
+import * as pulumi from '@pulumi/pulumi';
+
+export namespace PrometheusRemoteWriteExporter {
+  export type Config = {
+    namespace: pulumi.Input<string>;
+    endpoint: pulumi.Input<string>;
+    auth?: {
+      authenticator: pulumi.Input<string>;
+    };
+  };
+}
+

--- a/tests/otel/index.test.ts
+++ b/tests/otel/index.test.ts
@@ -157,30 +157,6 @@ describe('OtelCollectorConfigBuilder', () => {
     assert.deepStrictEqual(result, expected);
   });
 
-  it('should configure SigV4Auth extension', () => {
-    const result = new OtelCollectorConfigBuilder()
-      .withSigV4AuthExtension(awsRegion)
-      .build();
-
-    const expected = {
-      receivers: {},
-      processors: {},
-      exporters: {},
-      extensions: {
-        sigv4auth: {
-          region: awsRegion,
-          service: 'aps'
-        }
-      },
-      service: {
-        extensions: ['sigv4auth'],
-        pipelines: {}
-      }
-    };
-
-    assert.deepStrictEqual(result, expected);
-  });
-
   it('should configure health check extension', () => {
     const result = new OtelCollectorConfigBuilder()
       .withHealthCheckExtension()

--- a/tests/web-server/infrastructure/config.ts
+++ b/tests/web-server/infrastructure/config.ts
@@ -1,0 +1,2 @@
+export const webServerName = 'web-server-test';
+export const healthCheckPath = '/healthcheck';

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -1,11 +1,11 @@
 import { Project, next as studion } from '@studion/infra-code-blocks';
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
+import { webServerName, healthCheckPath } from './config';
 
-const serviceName = 'web-server-test';
 const stackName = pulumi.getStack();
-const project: Project = new Project(serviceName, { services: [] });
-const tags = { Env: stackName, Project: serviceName };
+const project: Project = new Project(webServerName, { services: [] });
+const tags = { Env: stackName, Project: webServerName };
 const init = {
   name: 'init',
   image: 'busybox:latest',
@@ -25,18 +25,18 @@ const sidecar = {
     startPeriod: 10
   }
 };
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(serviceName, stackName)
+const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(webServerName, stackName)
   .withOTLPReceiver()
   .withDebug()
   .withMetricsPipeline(['otlp'], [], ['debug'])
   .build();
 
-const cluster = new aws.ecs.Cluster(`${serviceName}-cluster`, {
-  name: `${serviceName}-cluster-${stackName}`,
+const cluster = new aws.ecs.Cluster(`${webServerName}-cluster`, {
+  name: `${webServerName}-cluster-${stackName}`,
   tags
 });
 
-const webServer = new studion.WebServerBuilder(serviceName)
+const webServer = new studion.WebServerBuilder(webServerName)
   .configureWebServer('nginxdemos/nginx-hello:plain-text', 8080)
   .configureEcs({
     cluster,
@@ -48,6 +48,7 @@ const webServer = new studion.WebServerBuilder(serviceName)
   .withSidecarContainer(sidecar)
   .withVpc(project.vpc)
   .withOtelCollector(otelCollector)
+  .withCustomHealthCheckPath(healthCheckPath)
   .build({ parent: cluster });
 
-export { project, webServer };
+export { project, webServer, otelCollector };

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -25,7 +25,7 @@ const sidecar = {
     startPeriod: 10
   }
 };
-const otelCollectorConfig = new studion.openTelemetry.OtelCollectorConfigBuilder()
+const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(serviceName, stackName)
   .withOTLPReceiver()
   .withDebug()
   .withMetricsPipeline(['otlp'], [], ['debug'])
@@ -47,7 +47,7 @@ const webServer = new studion.WebServerBuilder(serviceName)
   .withInitContainer(init)
   .withSidecarContainer(sidecar)
   .withVpc(project.vpc)
-  .withOtelCollector(otelCollectorConfig)
+  .withOtelCollector(otelCollector)
   .build({ parent: cluster });
 
 export { project, webServer };


### PR DESCRIPTION
- [x] enables APS (Amazon managed Prometheus Service) exporter by provisioning ECS task inline policy
- [x] provision ECS task inline policy for AWS X-Ray
- [x] expose `OtelCollectorBuilder` instead of `OtelCollectorConfigBuilder`
- [x] pass `OtelCollector` construct to `WebServer` instead of `OtelCollector.Config` 