### PR TITLE
fix: set parent for load balancer and access point

### DIFF
--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -652,7 +652,7 @@ export class EcsService extends pulumi.ComponentResource {
           permissions: FIRST_POSIX_NON_ROOT_USER.permissions,
         },
       },
-    });
+    }, { parent: this });
 
     return { fileSystem: efs, accessPoint };
   }

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -95,7 +95,7 @@ export class WebServer extends pulumi.ComponentResource {
       port: args.port,
       certificate: this.certificate?.certificate,
       healthCheckPath: args.healthCheckPath
-    });
+    }, { parent: this });
     this.serviceSecurityGroup = this.createSecurityGroup(vpc);
 
     this.initContainers = this.getInitContainers(args);


### PR DESCRIPTION
Ensure web server load balancer and ECS EFS access point have parent property set. 
Since parent is the `ResourceComponent`, it should not affect parallelization during 
resource creation, as it is only logical grouping that helps with the resource management.