### PR TITLE
feat: support available deployment controllers

### DIFF
--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -78,6 +78,11 @@ export namespace EcsService {
     loadBalancers?: pulumi.Input<LoadBalancerConfig[]>;
     volumes?: pulumi.Input<pulumi.Input<EcsService.PersistentStorageVolume>[]>;
     /**
+     * Type of deployment controller to use.
+     * @default "ECS"
+     */
+    deploymentController?: 'ECS' | 'CODE_DEPLOY' | 'EXTERNAL';
+    /**
      * Number of instances of the task definition to place and keep running.
      * @default 1
      */
@@ -152,6 +157,7 @@ const FIRST_POSIX_NON_ROOT_USER = {
 } as const;
 
 const defaults = {
+  deploymentController: 'ECS',
   desiredCount: 1,
   size: 'small',
   environment: [],
@@ -475,6 +481,7 @@ export class EcsService extends pulumi.ComponentResource {
         name: this.name,
         cluster: pulumi.output(ecsServiceArgs.cluster).id,
         launchType: 'FARGATE',
+        deploymentController: { type: ecsServiceArgs.deploymentController },
         desiredCount: ecsServiceArgs.desiredCount,
         taskDefinition: this.taskDefinition.arn,
         enableExecuteCommand: true,

--- a/src/v2/components/web-server/builder.ts
+++ b/src/v2/components/web-server/builder.ts
@@ -53,6 +53,7 @@ export class WebServerBuilder {
   public configureEcs(config: WebServerBuilder.EcsConfig): this {
     this._ecsConfig = {
       cluster: config.cluster,
+      deploymentController: config.deploymentController,
       desiredCount: config.desiredCount,
       autoscaling: config.autoscaling,
       size: config.size,

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -20,6 +20,7 @@ export namespace WebServer {
     | 'cluster'
     | 'vpc'
     | 'volumes'
+    | 'deploymentController'
     | 'desiredCount'
     | 'autoscaling'
     | 'size'
@@ -189,6 +190,7 @@ export class WebServer extends pulumi.ComponentResource {
     return {
       vpc: args.vpc,
       cluster: args.cluster,
+      deploymentController: args.deploymentController,
       desiredCount: args.desiredCount,
       autoscaling: args.autoscaling,
       size: args.size,


### PR DESCRIPTION
Both ECS service and web server v2 components support changing deployment controller 
to facilitate advanced deployment strategies. 
Supported deployment controllers - `ECS` | `CODE_DEPLOY` | `EXTERNAL`.