### PR TITLE
style: format codebase with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ type ProjectArgs = {
 };
 ```
 
-| Argument         |                                                                         Description                                                                          |
-| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| services \*      |                                                                        Service list.                                                                         |
-| enableSSMConnect | Set up ec2 instance and SSM in order to connect to the database in the private subnet. Please refer to the [SSM Connect](#ssm-connect) section for more info. |
-| numberOfAvailabilityZones | Default is 2 which is recommended. If building a dev server, we can reduce to 1 availability zone to reduce hosting cost. |
+| Argument                  |                                                                          Description                                                                          |
+| :------------------------ | :-----------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| services \*               |                                                                         Service list.                                                                         |
+| enableSSMConnect          | Set up ec2 instance and SSM in order to connect to the database in the private subnet. Please refer to the [SSM Connect](#ssm-connect) section for more info. |
+| numberOfAvailabilityZones |                   Default is 2 which is recommended. If building a dev server, we can reduce to 1 availability zone to reduce hosting cost.                   |
 
 ```ts
 type DatabaseServiceOptions = {
@@ -481,9 +481,11 @@ type DatabaseReplicaArgs = {
   }>;
 };
 ```
+
 Database replica requires primary DB instance to exist. If the replica is in the same
 region as primary instance, we should not set `dbSubnetGroupNameParam`.
 The `replicateSourceDb` param is referenced like this:
+
 ```javascript
   const primaryDb = new studion.Database(...);
   const replica = new studion.DatabaseReplica('replica', {

--- a/src/components/database-replica.ts
+++ b/src/components/database-replica.ts
@@ -130,7 +130,7 @@ export class DatabaseReplica extends pulumi.ComponentResource {
         ...monitoringOptions,
         tags: { ...commonTags, ...argsWithDefaults.tags },
       },
-      { parent: this }
+      { parent: this },
     );
     return instance;
   }

--- a/src/components/mongo.ts
+++ b/src/components/mongo.ts
@@ -53,10 +53,12 @@ export class Mongo extends pulumi.ComponentResource {
     const port = args.port || 27017;
     const persistentStorageConfig = args.persistentStorageConfig || {
       volumes: [{ name: 'mongo' }],
-      mountPoints: [{
-        sourceVolume: 'mongo',
-        containerPath:  '/data/db'
-      }]
+      mountPoints: [
+        {
+          sourceVolume: 'mongo',
+          containerPath: '/data/db',
+        },
+      ],
     };
 
     const { username, password, privateSubnetIds, ...ecsServiceArgs } = args;

--- a/src/components/web-server.ts
+++ b/src/components/web-server.ts
@@ -61,7 +61,7 @@ export class WebServer extends pulumi.ComponentResource {
     const aliases = opts.aliases || [];
     super('studion:LegacyWebServer', name, args, {
       ...opts,
-      aliases: [...aliases, { type: 'studion:WebServer' }]
+      aliases: [...aliases, { type: 'studion:WebServer' }],
     });
 
     const { vpcId, domain, hostedZoneId } = args;

--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -645,21 +645,25 @@ export class EcsService extends pulumi.ComponentResource {
       });
     });
 
-    const accessPoint = new aws.efs.AccessPoint(`${this.name}-efs-ap`, {
-      fileSystemId: efs.id,
-      posixUser: {
-        uid: FIRST_POSIX_NON_ROOT_USER.userId,
-        gid: FIRST_POSIX_NON_ROOT_USER.groupId,
-      },
-      rootDirectory: {
-        path: '/data',
-        creationInfo: {
-          ownerUid: FIRST_POSIX_NON_ROOT_USER.userId,
-          ownerGid: FIRST_POSIX_NON_ROOT_USER.groupId,
-          permissions: FIRST_POSIX_NON_ROOT_USER.permissions,
+    const accessPoint = new aws.efs.AccessPoint(
+      `${this.name}-efs-ap`,
+      {
+        fileSystemId: efs.id,
+        posixUser: {
+          uid: FIRST_POSIX_NON_ROOT_USER.userId,
+          gid: FIRST_POSIX_NON_ROOT_USER.groupId,
+        },
+        rootDirectory: {
+          path: '/data',
+          creationInfo: {
+            ownerUid: FIRST_POSIX_NON_ROOT_USER.userId,
+            ownerGid: FIRST_POSIX_NON_ROOT_USER.groupId,
+            permissions: FIRST_POSIX_NON_ROOT_USER.permissions,
+          },
         },
       },
-    }, { parent: this });
+      { parent: this },
+    );
 
     return { fileSystem: efs, accessPoint };
   }

--- a/src/v2/components/ecs-service/policies.ts
+++ b/src/v2/components/ecs-service/policies.ts
@@ -13,4 +13,3 @@ export const assumeRolePolicy: aws.iam.PolicyDocument = {
     },
   ],
 };
-

--- a/src/v2/components/grafana/dashboards/index.ts
+++ b/src/v2/components/grafana/dashboards/index.ts
@@ -1,2 +1,2 @@
-export { default as WebServerSloDashboardBuilder } from "./web-server-slo";
+export { default as WebServerSloDashboardBuilder } from './web-server-slo';
 export * as panel from './panels';

--- a/src/v2/components/grafana/dashboards/panels.ts
+++ b/src/v2/components/grafana/dashboards/panels.ts
@@ -3,35 +3,39 @@ import { Grafana } from './types';
 const percentageFieldConfig = {
   unit: 'percent',
   min: 0,
-  max: 100
-}
+  max: 100,
+};
 
 export function createStatPercentagePanel(
   title: string,
   position: Grafana.Panel.Position,
   dataSource: string,
-  metric: Grafana.Metric
+  metric: Grafana.Metric,
 ): Grafana.Panel {
   return {
     title,
     gridPos: position,
     type: 'stat',
     datasource: dataSource,
-    targets: [{
-      expr: metric.query,
-      legendFormat: metric.label
-    }],
+    targets: [
+      {
+        expr: metric.query,
+        legendFormat: metric.label,
+      },
+    ],
     fieldConfig: {
       defaults: {
         ...percentageFieldConfig,
-        ...(metric.thresholds ? {
-          thresholds: {
-            mode: 'absolute',
-            steps: metric.thresholds
-          }
-        } : {})
-      }
-    }
+        ...(metric.thresholds
+          ? {
+              thresholds: {
+                mode: 'absolute',
+                steps: metric.thresholds,
+              },
+            }
+          : {}),
+      },
+    },
   };
 }
 
@@ -39,7 +43,7 @@ export function createTimeSeriesPercentagePanel(
   title: string,
   position: Grafana.Panel.Position,
   dataSource: string,
-  metric: Grafana.Metric
+  metric: Grafana.Metric,
 ): Grafana.Panel {
   return createTimeSeriesPanel(
     title,
@@ -48,7 +52,7 @@ export function createTimeSeriesPercentagePanel(
     metric,
     percentageFieldConfig.unit,
     percentageFieldConfig.min,
-    percentageFieldConfig.max
+    percentageFieldConfig.max,
   );
 }
 
@@ -59,30 +63,34 @@ export function createTimeSeriesPanel(
   metric: Grafana.Metric,
   unit?: string,
   min?: number,
-  max?: number
+  max?: number,
 ): Grafana.Panel {
   return {
     title,
     type: 'timeseries',
     datasource: dataSource,
     gridPos: position,
-    targets: [{
-      expr: metric.query,
-      legendFormat: metric.label
-    }],
+    targets: [
+      {
+        expr: metric.query,
+        legendFormat: metric.label,
+      },
+    ],
     fieldConfig: {
       defaults: {
         unit,
         min,
         max,
-        ...(metric.thresholds ? {
-          thresholds: {
-            mode: 'absolute',
-            steps: metric.thresholds
-          }
-        } : {}),
-      }
-    }
+        ...(metric.thresholds
+          ? {
+              thresholds: {
+                mode: 'absolute',
+                steps: metric.thresholds,
+              },
+            }
+          : {}),
+      },
+    },
   };
 }
 
@@ -90,26 +98,28 @@ export function createBurnRatePanel(
   title: string,
   position: Grafana.Panel.Position,
   dataSource: string,
-  metric: Grafana.Metric
+  metric: Grafana.Metric,
 ): Grafana.Panel {
   return {
     type: 'stat',
     title,
     gridPos: position,
     datasource: dataSource,
-    targets: [{
-      expr: metric.query,
-      legendFormat: metric.label
-    }],
+    targets: [
+      {
+        expr: metric.query,
+        legendFormat: metric.label,
+      },
+    ],
     options: {
       reduceOptions: {
         calcs: ['last'],
         fields: '',
-        values: false
+        values: false,
       },
       colorMode: 'value',
       graphMode: 'none',
-      textMode: 'value'
+      textMode: 'value',
     },
     fieldConfig: {
       defaults: {
@@ -119,10 +129,10 @@ export function createBurnRatePanel(
           steps: [
             { color: 'green', value: null },
             { color: 'orange', value: 1 },
-            { color: 'red', value: 2 }
-          ]
-        }
-      }
+            { color: 'red', value: 2 },
+          ],
+        },
+      },
     },
-  }
+  };
 }

--- a/src/v2/components/grafana/dashboards/types.ts
+++ b/src/v2/components/grafana/dashboards/types.ts
@@ -44,9 +44,9 @@ export namespace Grafana {
           steps: Threshold[];
         };
         custom?: {
-          lineInterpolation?: string,
-          spanNulls: boolean
-        }
+          lineInterpolation?: string;
+          spanNulls: boolean;
+        };
       };
     };
     options?: {
@@ -60,7 +60,7 @@ export namespace Grafana {
         values?: boolean;
       };
     };
-  }
+  };
 
   export namespace Panel {
     export type Position = {
@@ -68,6 +68,6 @@ export namespace Grafana {
       y: number;
       w: number;
       h: number;
-    }
+    };
   }
 }

--- a/src/v2/components/grafana/dashboards/web-server-slo.ts
+++ b/src/v2/components/grafana/dashboards/web-server-slo.ts
@@ -1,12 +1,12 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
-import { queries as promQ } from '../../prometheus'
+import { queries as promQ } from '../../prometheus';
 import { Grafana } from './types';
 import {
   createBurnRatePanel,
   createStatPercentagePanel,
   createTimeSeriesPanel,
-  createTimeSeriesPercentagePanel
+  createTimeSeriesPercentagePanel,
 } from './panels';
 
 class WebServerSloDashboardBuilder {
@@ -15,10 +15,7 @@ class WebServerSloDashboardBuilder {
   panels: Grafana.Panel[] = [];
   tags?: pulumi.Output<string[]>;
 
-  constructor(
-    name: string,
-    args: Grafana.Args,
-  ) {
+  constructor(name: string, args: Grafana.Args) {
     this.name = name;
     this.title = pulumi.output(args.title);
   }
@@ -27,27 +24,37 @@ class WebServerSloDashboardBuilder {
     target: number,
     window: promQ.TimeRange,
     dataSource: string,
-    prometheusNamespace: string
+    prometheusNamespace: string,
   ): this {
-    const availabilityPercentage = promQ.getAvailabilityPercentageQuery(prometheusNamespace, window);
-    const availabilityBurnRate = promQ.getBurnRateQuery(promQ.getAvailabilityQuery(prometheusNamespace, '1h'), target);
+    const availabilityPercentage = promQ.getAvailabilityPercentageQuery(
+      prometheusNamespace,
+      window,
+    );
+    const availabilityBurnRate = promQ.getBurnRateQuery(
+      promQ.getAvailabilityQuery(prometheusNamespace, '1h'),
+      target,
+    );
 
     const availabilitySloPanel = createStatPercentagePanel(
       'Availability',
       { x: 0, y: 0, w: 8, h: 8 },
-      dataSource, {
-      label: 'Availability',
-      query: availabilityPercentage,
-      thresholds: []
-    });
+      dataSource,
+      {
+        label: 'Availability',
+        query: availabilityPercentage,
+        thresholds: [],
+      },
+    );
     const availabilityBurnRatePanel = createBurnRatePanel(
       'Availability Burn Rate',
       { x: 0, y: 8, w: 8, h: 4 },
-      dataSource, {
-      label: 'Burn Rate',
-      query: availabilityBurnRate,
-      thresholds: []
-    });
+      dataSource,
+      {
+        label: 'Burn Rate',
+        query: availabilityBurnRate,
+        thresholds: [],
+      },
+    );
 
     this.panels.push(availabilitySloPanel, availabilityBurnRatePanel);
 
@@ -60,11 +67,22 @@ class WebServerSloDashboardBuilder {
     shortWindow: promQ.TimeRange,
     filter: string,
     dataSource: string,
-    prometheusNamespace: string
+    prometheusNamespace: string,
   ): this {
-    const successRateSlo = promQ.getSuccessPercentageQuery(prometheusNamespace, window, filter);
-    const successRateBurnRate = promQ.getBurnRateQuery(promQ.getSuccessRateQuery(prometheusNamespace, '1h', filter), target);
-    const successRate = promQ.getSuccessPercentageQuery(prometheusNamespace, shortWindow, filter);
+    const successRateSlo = promQ.getSuccessPercentageQuery(
+      prometheusNamespace,
+      window,
+      filter,
+    );
+    const successRateBurnRate = promQ.getBurnRateQuery(
+      promQ.getSuccessRateQuery(prometheusNamespace, '1h', filter),
+      target,
+    );
+    const successRate = promQ.getSuccessPercentageQuery(
+      prometheusNamespace,
+      shortWindow,
+      filter,
+    );
 
     const successRateSloPanel = createStatPercentagePanel(
       'Success Rate',
@@ -73,8 +91,8 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Success Rate',
         query: successRateSlo,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
     const successRatePanel = createTimeSeriesPercentagePanel(
       'HTTP Request Success Rate',
@@ -83,8 +101,8 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Success Rate',
         query: successRate,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
     const successRateBurnRatePanel = createBurnRatePanel(
       'Success Rate Burn Rate',
@@ -93,11 +111,15 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Burn Rate',
         query: successRateBurnRate,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
 
-    this.panels.push(successRateSloPanel, successRatePanel, successRateBurnRatePanel);
+    this.panels.push(
+      successRateSloPanel,
+      successRatePanel,
+      successRateBurnRatePanel,
+    );
 
     return this;
   }
@@ -109,12 +131,30 @@ class WebServerSloDashboardBuilder {
     shortWindow: promQ.TimeRange,
     filter: string,
     dataSource: string,
-    prometheusNamespace: string
+    prometheusNamespace: string,
   ): this {
-    const latencySlo = promQ.getLatencyPercentageQuery(prometheusNamespace, window, targetLatency, filter);
-    const latencyBurnRate = promQ.getBurnRateQuery(promQ.getLatencyRateQuery(prometheusNamespace, '1h', targetLatency), target);
-    const percentileLatency = promQ.getPercentileLatencyQuery(prometheusNamespace, shortWindow, target, filter);
-    const latencyBelowThreshold = promQ.getLatencyPercentageQuery(prometheusNamespace, shortWindow, targetLatency, filter);
+    const latencySlo = promQ.getLatencyPercentageQuery(
+      prometheusNamespace,
+      window,
+      targetLatency,
+      filter,
+    );
+    const latencyBurnRate = promQ.getBurnRateQuery(
+      promQ.getLatencyRateQuery(prometheusNamespace, '1h', targetLatency),
+      target,
+    );
+    const percentileLatency = promQ.getPercentileLatencyQuery(
+      prometheusNamespace,
+      shortWindow,
+      target,
+      filter,
+    );
+    const latencyBelowThreshold = promQ.getLatencyPercentageQuery(
+      prometheusNamespace,
+      shortWindow,
+      targetLatency,
+      filter,
+    );
 
     const latencySloPanel = createStatPercentagePanel(
       'Request % below 250ms',
@@ -123,8 +163,8 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Request % below 250ms',
         query: latencySlo,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
     const percentileLatencyPanel = createTimeSeriesPanel(
       '99th Percentile Latency',
@@ -133,9 +173,9 @@ class WebServerSloDashboardBuilder {
       {
         label: '99th Percentile Latency',
         query: percentileLatency,
-        thresholds: []
+        thresholds: [],
       },
-      'ms'
+      'ms',
     );
     const latencyPercentagePanel = createTimeSeriesPercentagePanel(
       'Request percentage below 250ms',
@@ -144,8 +184,8 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Request percentage below 250ms',
         query: latencyBelowThreshold,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
     const latencyBurnRatePanel = createBurnRatePanel(
       'Latency Burn Rate',
@@ -154,42 +194,40 @@ class WebServerSloDashboardBuilder {
       {
         label: 'Burn Rate',
         query: latencyBurnRate,
-        thresholds: []
-      }
+        thresholds: [],
+      },
     );
 
     this.panels.push(
       latencySloPanel,
       percentileLatencyPanel,
       latencyPercentagePanel,
-      latencyBurnRatePanel
+      latencyBurnRatePanel,
     );
 
     return this;
   }
 
-  build(provider: pulumi.Output<grafana.Provider>): pulumi.Output<grafana.oss.Dashboard> {
-    return pulumi.all([
-      this.title,
-      this.panels,
-      provider,
-      this.tags
-    ]).apply(([
-      title,
-      panels,
-      provider,
-      tags
-    ]) => {
-      return new grafana.oss.Dashboard(this.name, {
-        configJson: JSON.stringify({
-          title,
-          tags,
-          timezone: 'browser',
-          refresh: '10s',
-          panels,
-        })
-      }, { provider });
-    });
+  build(
+    provider: pulumi.Output<grafana.Provider>,
+  ): pulumi.Output<grafana.oss.Dashboard> {
+    return pulumi
+      .all([this.title, this.panels, provider, this.tags])
+      .apply(([title, panels, provider, tags]) => {
+        return new grafana.oss.Dashboard(
+          this.name,
+          {
+            configJson: JSON.stringify({
+              title,
+              tags,
+              timezone: 'browser',
+              refresh: '10s',
+              panels,
+            }),
+          },
+          { provider },
+        );
+      });
   }
 }
 

--- a/src/v2/components/prometheus/queries.test.ts
+++ b/src/v2/components/prometheus/queries.test.ts
@@ -5,7 +5,7 @@ import {
   getSuccessRateQuery,
   getPercentileLatencyQuery,
   getLatencyPercentageQuery,
-  TimeRange
+  TimeRange,
 } from './queries';
 
 describe('Prometheus Query Builders', async () => {
@@ -36,9 +36,13 @@ describe('Prometheus Query Builders', async () => {
   describe('getPercentileLatencyQuery', async () => {
     it('should build correct query', () => {
       const percentile = 0.95;
-      const result = getPercentileLatencyQuery(namespace, timeRange, percentile, apiRouteFilter);
-      const expected =
-        `histogram_quantile(${percentile}, sum by(le) (rate(${namespace}_http_server_duration_milliseconds_bucket{${apiRouteFilter}}[${timeRange}])))`;
+      const result = getPercentileLatencyQuery(
+        namespace,
+        timeRange,
+        percentile,
+        apiRouteFilter,
+      );
+      const expected = `histogram_quantile(${percentile}, sum by(le) (rate(${namespace}_http_server_duration_milliseconds_bucket{${apiRouteFilter}}[${timeRange}])))`;
       assert.equal(result, expected);
     });
   });
@@ -46,7 +50,12 @@ describe('Prometheus Query Builders', async () => {
   describe('getLatencyPercentageQuery', async () => {
     it('should build correct query', () => {
       const threshold = 200;
-      const result = getLatencyPercentageQuery(namespace, timeRange, threshold, apiRouteFilter);
+      const result = getLatencyPercentageQuery(
+        namespace,
+        timeRange,
+        threshold,
+        apiRouteFilter,
+      );
       const expected =
         `(sum(rate(${namespace}_http_server_duration_milliseconds_bucket{le="200",${apiRouteFilter}}[2m]))) / ` +
         `(sum(rate(${namespace}_http_server_duration_milliseconds_count{${apiRouteFilter}}[2m]))) * 100`;

--- a/src/v2/components/prometheus/queries.ts
+++ b/src/v2/components/prometheus/queries.ts
@@ -5,34 +5,28 @@ const countPostfix = 'count';
 const bucketPostfix = 'bucket';
 const httpStatusCodeLabel = 'http_status_code';
 
-export function getBurnRateQuery(
-  metricQuery: string,
-  target: number
-): string {
-  return `(1 - ${metricQuery}) / ${(1 - target).toFixed(5)}`
+export function getBurnRateQuery(metricQuery: string, target: number): string {
+  return `(1 - ${metricQuery}) / ${(1 - target).toFixed(5)}`;
 }
 
 export function getAvailabilityQuery(
   namespace: string,
-  timeRange: TimeRange
+  timeRange: TimeRange,
 ): string {
   const successFilter = `${httpStatusCodeLabel}!~"5.."`;
   const successfulRequestsQuery = getCountRate(
     namespace,
     timeRange,
-    successFilter
+    successFilter,
   );
-  const totalRequestsQuery = getCountRate(
-    namespace,
-    timeRange
-  );
+  const totalRequestsQuery = getCountRate(namespace, timeRange);
 
   return `${successfulRequestsQuery} / ${totalRequestsQuery}`;
 }
 
 export function getAvailabilityPercentageQuery(
   namespace: string,
-  timeRange: TimeRange
+  timeRange: TimeRange,
 ): string {
   return `${getAvailabilityQuery(namespace, timeRange)} * 100`;
 }
@@ -40,7 +34,7 @@ export function getAvailabilityPercentageQuery(
 export function getSuccessRateQuery(
   namespace: string,
   timeRange: TimeRange,
-  filter: string
+  filter: string,
 ): string {
   const successFilter = [`${httpStatusCodeLabel}=~"[2-4].."`, filter].join(',');
   const totalFilter = filter;
@@ -48,13 +42,9 @@ export function getSuccessRateQuery(
   const successfulRequestsQuery = getCountRate(
     namespace,
     timeRange,
-    successFilter
+    successFilter,
   );
-  const totalRequestsQuery = getCountRate(
-    namespace,
-    timeRange,
-    totalFilter
-  );
+  const totalRequestsQuery = getCountRate(namespace, timeRange, totalFilter);
 
   return `${successfulRequestsQuery} / ${totalRequestsQuery}`;
 }
@@ -62,7 +52,7 @@ export function getSuccessRateQuery(
 export function getSuccessPercentageQuery(
   namespace: string,
   timeRange: TimeRange,
-  filter: string
+  filter: string,
 ): string {
   return `${getSuccessRateQuery(namespace, timeRange, filter)} * 100`;
 }
@@ -71,7 +61,7 @@ export function getPercentileLatencyQuery(
   namespace: string,
   timeRange: TimeRange,
   percentile: number,
-  filter: string
+  filter: string,
 ): string {
   const bucketMetric = getMetric(namespace, bucketPostfix, filter);
   const bucketRate = `sum by(le) (rate(${bucketMetric}[${timeRange}]))`;
@@ -83,14 +73,14 @@ export function getLatencyRateQuery(
   namespace: string,
   timeRange: TimeRange,
   threshold: number,
-  filter?: string
+  filter?: string,
 ): string {
   const filterWithThreshold = [`le="${threshold}"`, filter].join(',');
 
   const requestsUnderThreshold = getBucketRate(
     namespace,
     timeRange,
-    filterWithThreshold
+    filterWithThreshold,
   );
   const totalRequests = getCountRate(namespace, timeRange, filter);
 
@@ -101,7 +91,7 @@ export function getLatencyPercentageQuery(
   namespace: string,
   timeRange: TimeRange,
   threshold: number,
-  filter?: string
+  filter?: string,
 ): string {
   return `${getLatencyRateQuery(namespace, timeRange, threshold, filter)} * 100`;
 }
@@ -109,7 +99,7 @@ export function getLatencyPercentageQuery(
 function getCountRate(
   namespace: string,
   timeRange: TimeRange,
-  filter?: string
+  filter?: string,
 ): string {
   const countMetric = getMetric(namespace, countPostfix, filter);
 
@@ -119,7 +109,7 @@ function getCountRate(
 function getBucketRate(
   namespace: string,
   timeRange: TimeRange,
-  filter?: string
+  filter?: string,
 ): string {
   const bucketMetric = getMetric(namespace, bucketPostfix, filter);
 
@@ -129,7 +119,7 @@ function getBucketRate(
 function getMetric(
   namespace: string,
   postfix: string,
-  filter?: string
+  filter?: string,
 ): string {
   return `${namespace}_${metricName}_${postfix}${filter ? `{${filter}}` : ''}`;
 }

--- a/src/v2/components/web-server/builder.ts
+++ b/src/v2/components/web-server/builder.ts
@@ -16,7 +16,7 @@ export namespace WebServerBuilder {
     | 'domain'
     | 'hostedZoneId'
     | 'otelCollectorConfig'
-  >
+  >;
 }
 
 export class WebServerBuilder {
@@ -39,12 +39,12 @@ export class WebServerBuilder {
   public configureWebServer(
     image: WebServer.Container['image'],
     port: WebServer.Container['port'],
-    config: Omit<WebServer.Container, 'image' | 'port'> = {}
+    config: Omit<WebServer.Container, 'image' | 'port'> = {},
   ): this {
     this._container = {
       image,
       port,
-      ...config
+      ...config,
     };
 
     return this;
@@ -60,7 +60,7 @@ export class WebServerBuilder {
       taskExecutionRoleInlinePolicies: config.taskExecutionRoleInlinePolicies,
       taskRoleInlinePolicies: config.taskRoleInlinePolicies,
       tags: config.tags,
-    }
+    };
 
     return this;
   }
@@ -79,7 +79,7 @@ export class WebServerBuilder {
 
   public withCustomDomain(
     domain: pulumi.Input<string>,
-    hostedZoneId: pulumi.Input<string>
+    hostedZoneId: pulumi.Input<string>,
   ): this {
     this._domain = domain;
     this._hostedZoneId = hostedZoneId;
@@ -106,7 +106,7 @@ export class WebServerBuilder {
   }
 
   public withCustomHealthCheckPath(
-    path: WebServer.Args['healthCheckPath']
+    path: WebServer.Args['healthCheckPath'],
   ): this {
     this._healthCheckPath = path;
 
@@ -115,27 +115,37 @@ export class WebServerBuilder {
 
   public build(opts: pulumi.ComponentResourceOptions = {}): WebServer {
     if (!this._container) {
-      throw new Error('Web server not configured. Make sure to call WebServerBuilder.configureWebServer().');
+      throw new Error(
+        'Web server not configured. Make sure to call WebServerBuilder.configureWebServer().',
+      );
     }
     if (!this._ecsConfig) {
-      throw new Error('ECS not configured. Make sure to call WebServerBuilder.configureEcs().');
+      throw new Error(
+        'ECS not configured. Make sure to call WebServerBuilder.configureEcs().',
+      );
     }
     if (!this._vpc) {
-      throw new Error('VPC not provided. Make sure to call WebServerBuilder.withVpc().');
+      throw new Error(
+        'VPC not provided. Make sure to call WebServerBuilder.withVpc().',
+      );
     }
 
-    return new WebServer(this._name, {
-      ...this._ecsConfig,
-      ...this._container,
-      vpc: this._vpc,
-      volumes: this._volumes,
-      publicSubnetIds: this._vpc.publicSubnetIds,
-      domain: this._domain,
-      hostedZoneId: this._hostedZoneId,
-      healthCheckPath: this._healthCheckPath,
-      otelCollector: this._otelCollector,
-      initContainers: this._initContainers,
-      sidecarContainers: this._sidecarContainers
-    }, opts)
+    return new WebServer(
+      this._name,
+      {
+        ...this._ecsConfig,
+        ...this._container,
+        vpc: this._vpc,
+        volumes: this._volumes,
+        publicSubnetIds: this._vpc.publicSubnetIds,
+        domain: this._domain,
+        hostedZoneId: this._hostedZoneId,
+        healthCheckPath: this._healthCheckPath,
+        otelCollector: this._otelCollector,
+        initContainers: this._initContainers,
+        sidecarContainers: this._sidecarContainers,
+      },
+      opts,
+    );
   }
 }

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -30,13 +30,14 @@ export namespace WebServer {
   >;
 
   export type InitContainer = Omit<EcsService.Container, 'essential'>;
-  export type SidecarContainer =
-    & Omit<EcsService.Container, 'essential' | 'healthCheck'>
-    & Required<Pick<EcsService.Container, 'healthCheck'>>;
+  export type SidecarContainer = Omit<
+    EcsService.Container,
+    'essential' | 'healthCheck'
+  > &
+    Required<Pick<EcsService.Container, 'healthCheck'>>;
 
-  export type Args = EcsConfig
-    & Container
-    & {
+  export type Args = EcsConfig &
+    Container & {
       // TODO: Automatically use subnet IDs from passed `vpc`
       publicSubnetIds: pulumi.Input<pulumi.Input<string>[]>;
       /**
@@ -53,7 +54,9 @@ export namespace WebServer {
        */
       healthCheckPath?: pulumi.Input<string>;
       initContainers?: pulumi.Input<pulumi.Input<WebServer.InitContainer>[]>;
-      sidecarContainers?: pulumi.Input<pulumi.Input<WebServer.SidecarContainer>[]>;
+      sidecarContainers?: pulumi.Input<
+        pulumi.Input<WebServer.SidecarContainer>[]
+      >;
       otelCollector?: pulumi.Input<OtelCollector>;
     };
 }
@@ -91,12 +94,16 @@ export class WebServer extends pulumi.ComponentResource {
     }
 
     this.name = name;
-    this.lb = new WebServerLoadBalancer(`${this.name}-lb`, {
-      vpc,
-      port: args.port,
-      certificate: this.certificate?.certificate,
-      healthCheckPath: args.healthCheckPath
-    }, { parent: this });
+    this.lb = new WebServerLoadBalancer(
+      `${this.name}-lb`,
+      {
+        vpc,
+        port: args.port,
+        certificate: this.certificate?.certificate,
+        healthCheckPath: args.healthCheckPath,
+      },
+      { parent: this },
+    );
     this.serviceSecurityGroup = this.createSecurityGroup(vpc);
 
     this.initContainers = this.getInitContainers(args);
@@ -106,21 +113,17 @@ export class WebServer extends pulumi.ComponentResource {
     this.volumes = this.getVolumes(args);
 
     // TODO: Move output mapping to createEcsService
-    this.service = pulumi.all([
-      this.initContainers,
-      this.sidecarContainers,
-    ]).apply(([
-      initContainers,
-      sidecarContainers,
-    ]) => {
-      return this.createEcsService(
-        this.container,
-        this.lb,
-        this.ecsConfig,
-        this.volumes,
-        [...initContainers, ...sidecarContainers]
-      )
-    });
+    this.service = pulumi
+      .all([this.initContainers, this.sidecarContainers])
+      .apply(([initContainers, sidecarContainers]) => {
+        return this.createEcsService(
+          this.container,
+          this.lb,
+          this.ecsConfig,
+          this.volumes,
+          [...initContainers, ...sidecarContainers],
+        );
+      });
 
     if (hasCustomDomain) {
       this.dnsRecord = this.createDnsRecord({ domain, hostedZoneId });
@@ -129,62 +132,70 @@ export class WebServer extends pulumi.ComponentResource {
     this.registerOutputs();
   }
 
-  private getVolumes(args: WebServer.Args): pulumi.Output<EcsService.PersistentStorageVolume[]> {
-    return pulumi.all([
-      pulumi.output(args.volumes),
-      args.otelCollector
-    ]).apply(([passedVolumes, otelCollector]) => {
-      const volumes = [];
-      if (passedVolumes) volumes.push(...passedVolumes);
-      if (otelCollector) volumes.push({ name: otelCollector.configVolume });
+  private getVolumes(
+    args: WebServer.Args,
+  ): pulumi.Output<EcsService.PersistentStorageVolume[]> {
+    return pulumi
+      .all([pulumi.output(args.volumes), args.otelCollector])
+      .apply(([passedVolumes, otelCollector]) => {
+        const volumes = [];
+        if (passedVolumes) volumes.push(...passedVolumes);
+        if (otelCollector) volumes.push({ name: otelCollector.configVolume });
 
-      return volumes;
-    });
+        return volumes;
+      });
   }
 
-  private getInitContainers(args: WebServer.Args): pulumi.Output<EcsService.Container[]> {
-    return pulumi.all([
-      pulumi.output(args.initContainers),
-      args.otelCollector
-    ]).apply(([passedInits, otelCollector]) => {
-      const containers = [];
-      if (passedInits) containers.push(...passedInits);
-      if (otelCollector) containers.push(otelCollector.configContainer);
+  private getInitContainers(
+    args: WebServer.Args,
+  ): pulumi.Output<EcsService.Container[]> {
+    return pulumi
+      .all([pulumi.output(args.initContainers), args.otelCollector])
+      .apply(([passedInits, otelCollector]) => {
+        const containers = [];
+        if (passedInits) containers.push(...passedInits);
+        if (otelCollector) containers.push(otelCollector.configContainer);
 
-      return containers.map(container => ({ ...container, essential: false }));
-    });
+        return containers.map(container => ({
+          ...container,
+          essential: false,
+        }));
+      });
   }
 
-  private getSidecarContainers(args: WebServer.Args): pulumi.Output<EcsService.Container[]> {
-    return pulumi.all([
-      pulumi.output(args.sidecarContainers),
-      args.otelCollector
-    ]).apply(([passedSidecars, otelCollector]) => {
-      const containers = [];
-      if (passedSidecars) containers.push(...passedSidecars);
-      if (otelCollector) containers.push(otelCollector.container);
+  private getSidecarContainers(
+    args: WebServer.Args,
+  ): pulumi.Output<EcsService.Container[]> {
+    return pulumi
+      .all([pulumi.output(args.sidecarContainers), args.otelCollector])
+      .apply(([passedSidecars, otelCollector]) => {
+        const containers = [];
+        if (passedSidecars) containers.push(...passedSidecars);
+        if (otelCollector) containers.push(otelCollector.container);
 
-      return containers.map(container => ({ ...container, essential: true }));
-    });
+        return containers.map(container => ({ ...container, essential: true }));
+      });
   }
 
   private getTaskRoleInlinePolicies(
-    args: WebServer.Args
+    args: WebServer.Args,
   ): pulumi.Output<EcsService.RoleInlinePolicy[]> {
-    return pulumi.all([
-      pulumi.output(args.taskExecutionRoleInlinePolicies),
-      args.otelCollector
-    ]).apply(([passedTaskRoleInlinePolicies, otelCollector]) => {
-      const inlinePolicies = [];
-      if (passedTaskRoleInlinePolicies) inlinePolicies.push(...passedTaskRoleInlinePolicies);
-      if (otelCollector && otelCollector.taskRoleInlinePolicies) {
-        inlinePolicies.push(...otelCollector.taskRoleInlinePolicies);
-      }
+    return pulumi
+      .all([
+        pulumi.output(args.taskExecutionRoleInlinePolicies),
+        args.otelCollector,
+      ])
+      .apply(([passedTaskRoleInlinePolicies, otelCollector]) => {
+        const inlinePolicies = [];
+        if (passedTaskRoleInlinePolicies)
+          inlinePolicies.push(...passedTaskRoleInlinePolicies);
+        if (otelCollector && otelCollector.taskRoleInlinePolicies) {
+          inlinePolicies.push(...otelCollector.taskRoleInlinePolicies);
+        }
 
-      return inlinePolicies;
-    });
+        return inlinePolicies;
+      });
   }
-
 
   private createEcsConfig(args: WebServer.Args): WebServer.EcsConfig {
     return {
@@ -206,41 +217,55 @@ export class WebServer extends pulumi.ComponentResource {
       mountPoints: args.mountPoints,
       environment: args.environment,
       secrets: args.secrets,
-      port: args.port
+      port: args.port,
     };
   }
 
   private createTlsCertificate({
     domain,
     hostedZoneId,
-  }: Pick<Required<WebServer.Args>, 'domain' | 'hostedZoneId'>): AcmCertificate {
-    return new AcmCertificate(`${domain}-acm-certificate`, {
-      domain,
-      hostedZoneId,
-    }, { parent: this });
+  }: Pick<
+    Required<WebServer.Args>,
+    'domain' | 'hostedZoneId'
+  >): AcmCertificate {
+    return new AcmCertificate(
+      `${domain}-acm-certificate`,
+      {
+        domain,
+        hostedZoneId,
+      },
+      { parent: this },
+    );
   }
 
   private createSecurityGroup(
-    vpc: pulumi.Input<awsx.ec2.Vpc>
+    vpc: pulumi.Input<awsx.ec2.Vpc>,
   ): aws.ec2.SecurityGroup {
     const vpcId = pulumi.output(vpc).vpcId;
     return new aws.ec2.SecurityGroup(
-      `${this.name}-security-group`, {
-      vpcId,
-      ingress: [{
-        fromPort: 0,
-        toPort: 0,
-        protocol: '-1',
-        securityGroups: [this.lb.securityGroup.id],
-      }],
-      egress: [{
-        fromPort: 0,
-        toPort: 0,
-        protocol: '-1',
-        cidrBlocks: ['0.0.0.0/0'],
-      }],
-      tags: commonTags,
-    }, { parent: this });
+      `${this.name}-security-group`,
+      {
+        vpcId,
+        ingress: [
+          {
+            fromPort: 0,
+            toPort: 0,
+            protocol: '-1',
+            securityGroups: [this.lb.securityGroup.id],
+          },
+        ],
+        egress: [
+          {
+            fromPort: 0,
+            toPort: 0,
+            protocol: '-1',
+            cidrBlocks: ['0.0.0.0/0'],
+          },
+        ],
+        tags: commonTags,
+      },
+      { parent: this },
+    );
   }
 
   private createEcsService(
@@ -248,29 +273,40 @@ export class WebServer extends pulumi.ComponentResource {
     lb: WebServerLoadBalancer,
     ecsConfig: WebServer.EcsConfig,
     volumes?: pulumi.Output<EcsService.PersistentStorageVolume[]>,
-    containers?: EcsService.Container[]
+    containers?: EcsService.Container[],
   ): EcsService {
-    return new EcsService(`${this.name}-ecs`, {
-      ...ecsConfig,
-      volumes,
-      containers: [{
-        ...webServerContainer,
-        name: this.name,
-        portMappings: [EcsService.createTcpPortMapping(webServerContainer.port)],
-        essential: true
-      }, ...(containers || [])],
-      enableServiceAutoDiscovery: false,
-      loadBalancers: [{
-        containerName: this.name,
-        containerPort: webServerContainer.port,
-        targetGroupArn: lb.targetGroup.arn,
-      }],
-      assignPublicIp: true,
-      securityGroup: this.serviceSecurityGroup,
-    }, {
-      parent: this,
-      dependsOn: [lb, lb.targetGroup],
-    });
+    return new EcsService(
+      `${this.name}-ecs`,
+      {
+        ...ecsConfig,
+        volumes,
+        containers: [
+          {
+            ...webServerContainer,
+            name: this.name,
+            portMappings: [
+              EcsService.createTcpPortMapping(webServerContainer.port),
+            ],
+            essential: true,
+          },
+          ...(containers || []),
+        ],
+        enableServiceAutoDiscovery: false,
+        loadBalancers: [
+          {
+            containerName: this.name,
+            containerPort: webServerContainer.port,
+            targetGroupArn: lb.targetGroup.arn,
+          },
+        ],
+        assignPublicIp: true,
+        securityGroup: this.serviceSecurityGroup,
+      },
+      {
+        parent: this,
+        dependsOn: [lb, lb.targetGroup],
+      },
+    );
   }
 
   private createDnsRecord({
@@ -280,15 +316,21 @@ export class WebServer extends pulumi.ComponentResource {
     Required<WebServer.Args>,
     'domain' | 'hostedZoneId'
   >): aws.route53.Record {
-    return new aws.route53.Record(`${this.name}-route53-record`, {
-      type: 'A',
-      name: domain,
-      zoneId: hostedZoneId,
-      aliases: [{
-        name: this.lb.lb.dnsName,
-        zoneId: this.lb.lb.zoneId,
-        evaluateTargetHealth: true,
-      }],
-    }, { parent: this });
+    return new aws.route53.Record(
+      `${this.name}-route53-record`,
+      {
+        type: 'A',
+        name: domain,
+        zoneId: hostedZoneId,
+        aliases: [
+          {
+            name: this.lb.lb.dnsName,
+            zoneId: this.lb.lb.zoneId,
+            evaluateTargetHealth: true,
+          },
+        ],
+      },
+      { parent: this },
+    );
   }
 }

--- a/src/v2/components/web-server/load-balancer.ts
+++ b/src/v2/components/web-server/load-balancer.ts
@@ -13,23 +13,28 @@ export namespace WebServerLoadBalancer {
 }
 
 const webServerLoadBalancerNetworkConfig = {
-  ingress: [{
-    protocol: 'tcp',
-    fromPort: 80,
-    toPort: 80,
-    cidrBlocks: ['0.0.0.0/0'],
-  }, {
-    protocol: 'tcp',
-    fromPort: 443,
-    toPort: 443,
-    cidrBlocks: ['0.0.0.0/0'],
-  }],
-  egress: [{
-    fromPort: 0,
-    toPort: 0,
-    protocol: '-1',
-    cidrBlocks: ['0.0.0.0/0'],
-  }]
+  ingress: [
+    {
+      protocol: 'tcp',
+      fromPort: 80,
+      toPort: 80,
+      cidrBlocks: ['0.0.0.0/0'],
+    },
+    {
+      protocol: 'tcp',
+      fromPort: 443,
+      toPort: 443,
+      cidrBlocks: ['0.0.0.0/0'],
+    },
+  ],
+  egress: [
+    {
+      fromPort: 0,
+      toPort: 0,
+      protocol: '-1',
+      cidrBlocks: ['0.0.0.0/0'],
+    },
+  ],
 };
 
 const defaults = {
@@ -47,7 +52,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
   constructor(
     name: string,
     args: WebServerLoadBalancer.Args,
-    opts: pulumi.ComponentResourceOptions = {}
+    opts: pulumi.ComponentResourceOptions = {},
   ) {
     super('studion:WebServerLoadBalancer', name, args, opts);
 
@@ -57,27 +62,32 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
 
     this.securityGroup = this.createLbSecurityGroup(vpc.vpcId);
 
-    this.lb = new aws.lb.LoadBalancer(this.name, {
-      namePrefix: 'lb-',
-      loadBalancerType: 'application',
-      subnets: vpc.publicSubnetIds,
-      securityGroups: [this.securityGroup.id],
-      internal: false,
-      ipAddressType: 'ipv4',
-      tags: { ...commonTags, Name: name },
-    }, { parent: this });
+    this.lb = new aws.lb.LoadBalancer(
+      this.name,
+      {
+        namePrefix: 'lb-',
+        loadBalancerType: 'application',
+        subnets: vpc.publicSubnetIds,
+        securityGroups: [this.securityGroup.id],
+        internal: false,
+        ipAddressType: 'ipv4',
+        tags: { ...commonTags, Name: name },
+      },
+      { parent: this },
+    );
 
     this.targetGroup = this.createLbTargetGroup(
       port,
       vpc.vpcId,
-      healthCheckPath
+      healthCheckPath,
     );
     this.httpListener = this.createLbHttpListener(
       this.lb,
       this.targetGroup,
-      !!certificate
+      !!certificate,
     );
-    this.tlsListener = certificate &&
+    this.tlsListener =
+      certificate &&
       this.createLbTlsListener(this.lb, this.targetGroup, certificate);
 
     this.registerOutputs();
@@ -86,26 +96,32 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
   private createLbTlsListener(
     lb: aws.lb.LoadBalancer,
     lbTargetGroup: aws.lb.TargetGroup,
-    certificate: aws.acm.Certificate
+    certificate: aws.acm.Certificate,
   ): aws.lb.Listener {
-    return new aws.lb.Listener(`${this.name}-listener-443`, {
-      loadBalancerArn: lb.arn,
-      port: 443,
-      protocol: 'HTTPS',
-      sslPolicy: 'ELBSecurityPolicy-2016-08',
-      certificateArn: certificate.arn,
-      defaultActions: [{
-        type: 'forward',
-        targetGroupArn: lbTargetGroup.arn,
-      }],
-      tags: commonTags,
-    }, { parent: this, dependsOn: [certificate] });
+    return new aws.lb.Listener(
+      `${this.name}-listener-443`,
+      {
+        loadBalancerArn: lb.arn,
+        port: 443,
+        protocol: 'HTTPS',
+        sslPolicy: 'ELBSecurityPolicy-2016-08',
+        certificateArn: certificate.arn,
+        defaultActions: [
+          {
+            type: 'forward',
+            targetGroupArn: lbTargetGroup.arn,
+          },
+        ],
+        tags: commonTags,
+      },
+      { parent: this, dependsOn: [certificate] },
+    );
   }
 
   private createLbHttpListener(
     lb: aws.lb.LoadBalancer,
     lbTargetGroup: aws.lb.TargetGroup,
-    redirectToHttps: boolean
+    redirectToHttps: boolean,
   ): aws.lb.Listener {
     const httpsRedirectAction = {
       type: 'redirect',
@@ -115,48 +131,62 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
         statusCode: 'HTTP_301',
       },
     };
-    const defaultAction = redirectToHttps ? httpsRedirectAction : {
-      type: 'forward',
-      targetGroupArn: lbTargetGroup.arn,
-    };
+    const defaultAction = redirectToHttps
+      ? httpsRedirectAction
+      : {
+          type: 'forward',
+          targetGroupArn: lbTargetGroup.arn,
+        };
 
-    return new aws.lb.Listener(`${this.name}-listener-80`, {
-      loadBalancerArn: lb.arn,
-      port: 80,
-      defaultActions: [defaultAction],
-      tags: commonTags,
-    }, { parent: this });
+    return new aws.lb.Listener(
+      `${this.name}-listener-80`,
+      {
+        loadBalancerArn: lb.arn,
+        port: 80,
+        defaultActions: [defaultAction],
+        tags: commonTags,
+      },
+      { parent: this },
+    );
   }
 
   private createLbTargetGroup(
     port: pulumi.Input<number>,
     vpcId: awsx.ec2.Vpc['vpcId'],
-    healthCheckPath: pulumi.Input<string> | undefined
+    healthCheckPath: pulumi.Input<string> | undefined,
   ): aws.lb.TargetGroup {
-    return new aws.lb.TargetGroup(`${this.name}-tg`, {
-      namePrefix: 'lb-tg-',
-      port,
-      protocol: 'HTTP',
-      targetType: 'ip',
-      vpcId,
-      healthCheck: {
-        healthyThreshold: 3,
-        unhealthyThreshold: 2,
-        interval: 60,
-        timeout: 5,
-        path: healthCheckPath || defaults.healthCheckPath,
+    return new aws.lb.TargetGroup(
+      `${this.name}-tg`,
+      {
+        namePrefix: 'lb-tg-',
+        port,
+        protocol: 'HTTP',
+        targetType: 'ip',
+        vpcId,
+        healthCheck: {
+          healthyThreshold: 3,
+          unhealthyThreshold: 2,
+          interval: 60,
+          timeout: 5,
+          path: healthCheckPath || defaults.healthCheckPath,
+        },
+        tags: { ...commonTags, Name: `${this.name}-target-group` },
       },
-      tags: { ...commonTags, Name: `${this.name}-target-group` },
-    }, { parent: this, dependsOn: [this.lb] });
+      { parent: this, dependsOn: [this.lb] },
+    );
   }
 
   private createLbSecurityGroup(
-    vpcId: awsx.ec2.Vpc['vpcId']
+    vpcId: awsx.ec2.Vpc['vpcId'],
   ): aws.ec2.SecurityGroup {
-    return new aws.ec2.SecurityGroup(`${this.name}-security-group`, {
-      ...webServerLoadBalancerNetworkConfig,
-      vpcId,
-      tags: commonTags,
-    }, { parent: this });
+    return new aws.ec2.SecurityGroup(
+      `${this.name}-security-group`,
+      {
+        ...webServerLoadBalancerNetworkConfig,
+        vpcId,
+        tags: commonTags,
+      },
+      { parent: this },
+    );
   }
 }

--- a/src/v2/otel/batch-processor.ts
+++ b/src/v2/otel/batch-processor.ts
@@ -10,5 +10,5 @@ export const defaults = {
   name: 'batch',
   size: 8192,
   maxSize: 10000,
-  timeout: '5s'
+  timeout: '5s',
 };

--- a/src/v2/otel/memory-limiter-processor.ts
+++ b/src/v2/otel/memory-limiter-processor.ts
@@ -9,5 +9,5 @@ export namespace MemoryLimiterProcessor {
 export const defaults = {
   checkInterval: '1s',
   limitPercentage: 80,
-  spikeLimitPercentage: 15
+  spikeLimitPercentage: 15,
 };

--- a/src/v2/otel/otlp-receiver.ts
+++ b/src/v2/otel/otlp-receiver.ts
@@ -11,10 +11,9 @@ export namespace OTLPReceiver {
 
 export const Protocol = {
   grpc: {
-    endpoint: '0.0.0.0:4317'
+    endpoint: '0.0.0.0:4317',
   },
   http: {
-    endpoint: '0.0.0.0:4318'
-  }
+    endpoint: '0.0.0.0:4318',
+  },
 };
-

--- a/src/v2/otel/prometheus-remote-write-exporter.ts
+++ b/src/v2/otel/prometheus-remote-write-exporter.ts
@@ -9,4 +9,3 @@ export namespace PrometheusRemoteWriteExporter {
     };
   };
 }
-

--- a/tests/automation.ts
+++ b/tests/automation.ts
@@ -2,7 +2,7 @@ import {
   DestroyResult,
   InlineProgramArgs,
   LocalWorkspace,
-  OutputMap
+  OutputMap,
 } from '@pulumi/pulumi/automation';
 import { createSpinner } from 'nanospinner';
 

--- a/tests/ecs-service/autoscaling.test.ts
+++ b/tests/ecs-service/autoscaling.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 import { EcsTestContext } from './test-context';
 import {
   DescribeScalableTargetsCommand,
-  DescribeScalingPoliciesCommand
+  DescribeScalingPoliciesCommand,
 } from '@aws-sdk/client-application-auto-scaling';
 
 export function testEcsServiceWithAutoscaling(ctx: EcsTestContext) {
@@ -17,15 +17,27 @@ export function testEcsServiceWithAutoscaling(ctx: EcsTestContext) {
     const targetsCommand = new DescribeScalableTargetsCommand({
       ServiceNamespace: 'ecs',
       ResourceIds: [resourceId],
-      ScalableDimension: 'ecs:service:DesiredCount'
+      ScalableDimension: 'ecs:service:DesiredCount',
     });
 
-    const { ScalableTargets } = await ctx.clients.appAutoscaling.send(targetsCommand);
+    const { ScalableTargets } =
+      await ctx.clients.appAutoscaling.send(targetsCommand);
 
-    assert.ok(ScalableTargets && ScalableTargets.length > 0, 'Autoscaling target should exist');
+    assert.ok(
+      ScalableTargets && ScalableTargets.length > 0,
+      'Autoscaling target should exist',
+    );
 
-    assert.strictEqual(ScalableTargets[0].MinCapacity, 2, 'Min capacity should match configuration');
-    assert.strictEqual(ScalableTargets[0].MaxCapacity, 5, 'Max capacity should match configuration');
+    assert.strictEqual(
+      ScalableTargets[0].MinCapacity,
+      2,
+      'Min capacity should match configuration',
+    );
+    assert.strictEqual(
+      ScalableTargets[0].MaxCapacity,
+      5,
+      'Max capacity should match configuration',
+    );
   });
 
   it('should create CPU and memory scaling policies', async () => {
@@ -38,22 +50,34 @@ export function testEcsServiceWithAutoscaling(ctx: EcsTestContext) {
     const policiesCommand = new DescribeScalingPoliciesCommand({
       ServiceNamespace: 'ecs',
       ResourceId: resourceId,
-      ScalableDimension: 'ecs:service:DesiredCount'
+      ScalableDimension: 'ecs:service:DesiredCount',
     });
 
-    const { ScalingPolicies } = await ctx.clients.appAutoscaling.send(policiesCommand);
+    const { ScalingPolicies } =
+      await ctx.clients.appAutoscaling.send(policiesCommand);
 
-    assert.ok(ScalingPolicies && ScalingPolicies.length > 0, 'Autoscaling policies should exist');
-    assert.strictEqual(ScalingPolicies.length, 2, 'Should have 2 scaling policies (CPU and memory)');
-
-    const cpuPolicy = ScalingPolicies.find((policy: any) =>
-      policy.TargetTrackingScalingPolicyConfiguration?.PredefinedMetricSpecification?.PredefinedMetricType ===
-      'ECSServiceAverageCPUUtilization'
+    assert.ok(
+      ScalingPolicies && ScalingPolicies.length > 0,
+      'Autoscaling policies should exist',
+    );
+    assert.strictEqual(
+      ScalingPolicies.length,
+      2,
+      'Should have 2 scaling policies (CPU and memory)',
     );
 
-    const memoryPolicy = ScalingPolicies.find((policy: any) =>
-      policy.TargetTrackingScalingPolicyConfiguration?.PredefinedMetricSpecification?.PredefinedMetricType ===
-      'ECSServiceAverageMemoryUtilization'
+    const cpuPolicy = ScalingPolicies.find(
+      (policy: any) =>
+        policy.TargetTrackingScalingPolicyConfiguration
+          ?.PredefinedMetricSpecification?.PredefinedMetricType ===
+        'ECSServiceAverageCPUUtilization',
+    );
+
+    const memoryPolicy = ScalingPolicies.find(
+      (policy: any) =>
+        policy.TargetTrackingScalingPolicyConfiguration
+          ?.PredefinedMetricSpecification?.PredefinedMetricType ===
+        'ECSServiceAverageMemoryUtilization',
     );
 
     assert.ok(cpuPolicy, 'CPU autoscaling policy should exist');
@@ -62,12 +86,12 @@ export function testEcsServiceWithAutoscaling(ctx: EcsTestContext) {
     assert.strictEqual(
       cpuPolicy?.TargetTrackingScalingPolicyConfiguration?.TargetValue,
       70,
-      'CPU policy target should be 70%'
+      'CPU policy target should be 70%',
     );
     assert.strictEqual(
       memoryPolicy?.TargetTrackingScalingPolicyConfiguration?.TargetValue,
       70,
-      'Memory policy target should be 70%'
+      'Memory policy target should be 70%',
     );
   });
 }

--- a/tests/ecs-service/infrastructure/index.ts
+++ b/tests/ecs-service/infrastructure/index.ts
@@ -7,8 +7,8 @@ const stackName = pulumi.getStack();
 const appPort = 80;
 const tags = {
   Project: appName,
-  Environment: stackName
-}
+  Environment: stackName,
+};
 const sampleServiceContainer = {
   name: 'sample-service',
   image: 'amazon/amazon-ecs-sample',
@@ -17,10 +17,14 @@ const sampleServiceContainer = {
 
 const project = new Project(appName, { services: [] });
 
-const cluster = new aws.ecs.Cluster(`${appName}-cluster`, {
-  name: `${appName}-cluster-${stackName}`,
-  tags,
-}, { parent: project });
+const cluster = new aws.ecs.Cluster(
+  `${appName}-cluster`,
+  {
+    name: `${appName}-cluster-${stackName}`,
+    tags,
+  },
+  { parent: project },
+);
 
 const minimalEcsService = new studion.EcsService(`${appName}-min`, {
   cluster,
@@ -31,50 +35,56 @@ const minimalEcsService = new studion.EcsService(`${appName}-min`, {
 
 const lbSecurityGroup = new aws.ec2.SecurityGroup(`${appName}-lb-sg`, {
   vpcId: project.vpc.vpcId,
-  ingress: [{
-    protocol: "tcp",
-    fromPort: appPort,
-    toPort: appPort,
-    cidrBlocks: ["0.0.0.0/0"]
-  }],
-  egress: [{
-    protocol: "-1",
-    fromPort: 0,
-    toPort: 0,
-    cidrBlocks: ["0.0.0.0/0"]
-  }],
-  tags
+  ingress: [
+    {
+      protocol: 'tcp',
+      fromPort: appPort,
+      toPort: appPort,
+      cidrBlocks: ['0.0.0.0/0'],
+    },
+  ],
+  egress: [
+    {
+      protocol: '-1',
+      fromPort: 0,
+      toPort: 0,
+      cidrBlocks: ['0.0.0.0/0'],
+    },
+  ],
+  tags,
 });
 
 const lb = new aws.lb.LoadBalancer(`${appName}-lb`, {
   internal: false,
-  loadBalancerType: "application",
+  loadBalancerType: 'application',
   securityGroups: [lbSecurityGroup.id],
   subnets: project.vpc.publicSubnetIds,
-  tags
+  tags,
 });
 
 const targetGroup = new aws.lb.TargetGroup(`${appName}-tg`, {
   port: appPort,
-  protocol: "HTTP",
-  targetType: "ip",
+  protocol: 'HTTP',
+  targetType: 'ip',
   vpcId: project.vpc.vpcId,
   healthCheck: {
-    path: "/",
-    port: "traffic-port",
+    path: '/',
+    port: 'traffic-port',
   },
-  tags
+  tags,
 });
 
 const listener = new aws.lb.Listener(`${appName}-listener`, {
   loadBalancerArn: lb.arn,
   port: appPort,
-  protocol: "HTTP",
-  defaultActions: [{
-    type: "forward",
-    targetGroupArn: targetGroup.arn,
-  }],
-  tags
+  protocol: 'HTTP',
+  defaultActions: [
+    {
+      type: 'forward',
+      targetGroupArn: targetGroup.arn,
+    },
+  ],
+  tags,
 });
 
 const ecsServiceWithLb = new studion.EcsService(`${appName}-lb`, {
@@ -82,12 +92,14 @@ const ecsServiceWithLb = new studion.EcsService(`${appName}-lb`, {
   vpc: project.vpc,
   containers: [sampleServiceContainer],
   assignPublicIp: true,
-  loadBalancers: [{
-    containerName: 'sample-service',
-    containerPort: appPort,
-    targetGroupArn: targetGroup.arn,
-  }],
-  tags
+  loadBalancers: [
+    {
+      containerName: 'sample-service',
+      containerPort: appPort,
+      targetGroupArn: targetGroup.arn,
+    },
+  ],
+  tags,
 });
 
 const lbUrl = pulumi.interpolate`http://${lb.dnsName}`;
@@ -97,69 +109,80 @@ const ecsWithDiscovery = new studion.EcsService(`${appName}-sd`, {
   vpc: project.vpc,
   containers: [sampleServiceContainer],
   enableServiceAutoDiscovery: true,
-  tags
+  tags,
 });
 
-const ecsServiceWithAutoscaling = new studion.EcsService(`${appName}-autoscale`, {
-  cluster,
-  vpc: project.vpc,
-  containers: [sampleServiceContainer],
-  autoscaling: {
-    enabled: true,
-    minCount: 2,
-    maxCount: 5
+const ecsServiceWithAutoscaling = new studion.EcsService(
+  `${appName}-autoscale`,
+  {
+    cluster,
+    vpc: project.vpc,
+    containers: [sampleServiceContainer],
+    autoscaling: {
+      enabled: true,
+      minCount: 2,
+      maxCount: 5,
+    },
+    tags,
   },
-  tags
-});
+);
 
 const ecsServiceWithStorage = new studion.EcsService(`${appName}-storage`, {
   cluster,
   vpc: project.vpc,
-  volumes: [{ name: "data-volume" }],
-  containers: [{
-    name: "test-container",
-    image: "amazonlinux:2",
-    portMappings: [studion.EcsService.createTcpPortMapping(appPort)],
-    mountPoints: [{
-      sourceVolume: "data-volume",
-      containerPath: "/data"
-    }],
-    environment: [
-      { name: "TEST_FILE", value: "/data/test.txt" }
-    ],
-    // Enables testing EFS functionality based on logs.
-    // Command writes to EFS, then reads from it.
-    command: [
-      "sh",
-      "-c",
-      "echo 'EFS test content' > $TEST_FILE && " +
-      "if [ -f $TEST_FILE ] && grep 'EFS test content' $TEST_FILE; then " +
-      "echo 'Successfully wrote to and read from EFS volume'; " +
-      "else " +
-      "echo 'Failed to write to or read from EFS volume'; " +
-      "exit 1; " +
-      "fi && " +
-      "while true; do sleep 30; done"
-    ]
-  }],
-  tags
+  volumes: [{ name: 'data-volume' }],
+  containers: [
+    {
+      name: 'test-container',
+      image: 'amazonlinux:2',
+      portMappings: [studion.EcsService.createTcpPortMapping(appPort)],
+      mountPoints: [
+        {
+          sourceVolume: 'data-volume',
+          containerPath: '/data',
+        },
+      ],
+      environment: [{ name: 'TEST_FILE', value: '/data/test.txt' }],
+      // Enables testing EFS functionality based on logs.
+      // Command writes to EFS, then reads from it.
+      command: [
+        'sh',
+        '-c',
+        "echo 'EFS test content' > $TEST_FILE && " +
+          "if [ -f $TEST_FILE ] && grep 'EFS test content' $TEST_FILE; then " +
+          "echo 'Successfully wrote to and read from EFS volume'; " +
+          'else ' +
+          "echo 'Failed to write to or read from EFS volume'; " +
+          'exit 1; ' +
+          'fi && ' +
+          'while true; do sleep 30; done',
+      ],
+    },
+  ],
+  tags,
 });
 
-const ecsServiceWithEmptyVolumes = new studion.EcsService(`${appName}-empty-vol`, {
-  cluster,
-  vpc: project.vpc,
-  containers: [sampleServiceContainer],
-  volumes: [],
-  tags
-});
+const ecsServiceWithEmptyVolumes = new studion.EcsService(
+  `${appName}-empty-vol`,
+  {
+    cluster,
+    vpc: project.vpc,
+    containers: [sampleServiceContainer],
+    volumes: [],
+    tags,
+  },
+);
 
-const ecsServiceWithOutputEmptyVolumes = new studion.EcsService(`${appName}-empty-otp-vol`, {
-  cluster,
-  vpc: project.vpc,
-  containers: [sampleServiceContainer],
-  volumes: pulumi.output([]),
-  tags
-});
+const ecsServiceWithOutputEmptyVolumes = new studion.EcsService(
+  `${appName}-empty-otp-vol`,
+  {
+    cluster,
+    vpc: project.vpc,
+    containers: [sampleServiceContainer],
+    volumes: pulumi.output([]),
+    tags,
+  },
+);
 
 module.exports = {
   project,
@@ -171,5 +194,5 @@ module.exports = {
   ecsServiceWithAutoscaling,
   ecsServiceWithStorage,
   ecsServiceWithEmptyVolumes,
-  ecsServiceWithOutputEmptyVolumes
+  ecsServiceWithOutputEmptyVolumes,
 };

--- a/tests/ecs-service/load-balancer.test.ts
+++ b/tests/ecs-service/load-balancer.test.ts
@@ -2,47 +2,76 @@ import { it } from 'node:test';
 import * as assert from 'node:assert';
 import { backOff } from 'exponential-backoff';
 import { EcsTestContext } from './test-context';
-import { DescribeTargetGroupsCommand, DescribeTargetHealthCommand } from '@aws-sdk/client-elastic-load-balancing-v2';
+import {
+  DescribeTargetGroupsCommand,
+  DescribeTargetHealthCommand,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
 
 export function testEcsServiceWithLb(ctx: EcsTestContext) {
   it('should properly configure load balancer when provided', async () => {
     const ecsService = ctx.outputs.ecsServiceWithLb.value;
 
-    assert.ok(ecsService.service.loadBalancers &&
-      ecsService.service.loadBalancers.length > 0,
-      'Service should have load balancer configuration');
+    assert.ok(
+      ecsService.service.loadBalancers &&
+        ecsService.service.loadBalancers.length > 0,
+      'Service should have load balancer configuration',
+    );
 
     const [lbConfig] = ecsService.service.loadBalancers;
-    assert.strictEqual(lbConfig.containerName, 'sample-service', 'Load balancer should target correct container');
-    assert.strictEqual(lbConfig.containerPort, 80, 'Load balancer should target correct port');
+    assert.strictEqual(
+      lbConfig.containerName,
+      'sample-service',
+      'Load balancer should target correct container',
+    );
+    assert.strictEqual(
+      lbConfig.containerPort,
+      80,
+      'Load balancer should target correct port',
+    );
 
     const targetGroupArn = lbConfig.targetGroupArn;
     const describeTargetGroups = new DescribeTargetGroupsCommand({
-      TargetGroupArns: [targetGroupArn]
+      TargetGroupArns: [targetGroupArn],
     });
     const { TargetGroups } = await ctx.clients.elb.send(describeTargetGroups);
 
-    assert.ok(TargetGroups && TargetGroups.length > 0, 'Target group should exist');
-    assert.strictEqual(TargetGroups[0].TargetType, 'ip', 'Target group should be IP-based for Fargate');
+    assert.ok(
+      TargetGroups && TargetGroups.length > 0,
+      'Target group should exist',
+    );
+    assert.strictEqual(
+      TargetGroups[0].TargetType,
+      'ip',
+      'Target group should be IP-based for Fargate',
+    );
 
     const describeHealth = new DescribeTargetHealthCommand({
-      TargetGroupArn: targetGroupArn
+      TargetGroupArn: targetGroupArn,
     });
 
-    return backOff(async () => {
-      const { TargetHealthDescriptions } = await ctx.clients.elb.send(describeHealth);
-      assert.ok(TargetHealthDescriptions && TargetHealthDescriptions.length > 0,
-        'Target group should have registered targets');
+    return backOff(
+      async () => {
+        const { TargetHealthDescriptions } =
+          await ctx.clients.elb.send(describeHealth);
+        assert.ok(
+          TargetHealthDescriptions && TargetHealthDescriptions.length > 0,
+          'Target group should have registered targets',
+        );
 
-      // At least one target should be healthy
-      const healthyTargets = TargetHealthDescriptions.filter(
-        (target: any) => target.TargetHealth?.State === 'healthy'
-      );
-      assert.ok(healthyTargets.length > 0, 'At least one target should be healthy');
-    }, {
-      ...ctx.config.exponentialBackOffConfig,
-      numOfAttempts: 10,
-    });
+        // At least one target should be healthy
+        const healthyTargets = TargetHealthDescriptions.filter(
+          (target: any) => target.TargetHealth?.State === 'healthy',
+        );
+        assert.ok(
+          healthyTargets.length > 0,
+          'At least one target should be healthy',
+        );
+      },
+      {
+        ...ctx.config.exponentialBackOffConfig,
+        numOfAttempts: 10,
+      },
+    );
   });
 
   it('should be able to access the service via load balancer URL', async () => {
@@ -50,11 +79,17 @@ export function testEcsServiceWithLb(ctx: EcsTestContext) {
 
     return backOff(async () => {
       const response = await fetch(url);
-      assert.strictEqual(response.status, 200, 'HTTP request should return 200 OK');
+      assert.strictEqual(
+        response.status,
+        200,
+        'HTTP request should return 200 OK',
+      );
 
       const text = await response.text();
-      assert.ok(text.includes('Simple PHP App'),
-        'Response should contain expected content');
+      assert.ok(
+        text.includes('Simple PHP App'),
+        'Response should contain expected content',
+      );
     }, ctx.config.exponentialBackOffConfig);
   });
 }

--- a/tests/ecs-service/persistent-storage.test.ts
+++ b/tests/ecs-service/persistent-storage.test.ts
@@ -4,13 +4,13 @@ import {
   DescribeAccessPointsCommand,
   DescribeFileSystemsCommand,
   DescribeMountTargetsCommand,
-  DescribeMountTargetSecurityGroupsCommand
+  DescribeMountTargetSecurityGroupsCommand,
 } from '@aws-sdk/client-efs';
 import { DescribeSecurityGroupsCommand } from '@aws-sdk/client-ec2';
 import {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
-  GetLogEventsCommand
+  GetLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { DescribeTasksCommand, ListTasksCommand } from '@aws-sdk/client-ecs';
 import { backOff } from 'exponential-backoff';
@@ -24,14 +24,29 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
     assert.ok(efsFileSystem, 'EFS file system should be created');
 
     const command = new DescribeFileSystemsCommand({
-      FileSystemId: efsFileSystem.id
+      FileSystemId: efsFileSystem.id,
     });
     const { FileSystems } = await ctx.clients.efs.send(command);
 
-    assert.ok(FileSystems && FileSystems.length === 1, 'File system should exist');
-    assert.strictEqual(FileSystems[0].Encrypted, true, 'File system should be encrypted');
-    assert.strictEqual(FileSystems[0].PerformanceMode, 'generalPurpose', 'Should use general purpose performance mode');
-    assert.strictEqual(FileSystems[0].ThroughputMode, 'bursting', 'Should use bursting throughput mode');
+    assert.ok(
+      FileSystems && FileSystems.length === 1,
+      'File system should exist',
+    );
+    assert.strictEqual(
+      FileSystems[0].Encrypted,
+      true,
+      'File system should be encrypted',
+    );
+    assert.strictEqual(
+      FileSystems[0].PerformanceMode,
+      'generalPurpose',
+      'Should use general purpose performance mode',
+    );
+    assert.strictEqual(
+      FileSystems[0].ThroughputMode,
+      'bursting',
+      'Should use bursting throughput mode',
+    );
   });
 
   it('should create security group for EFS with correct rules', async () => {
@@ -39,41 +54,67 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
     const vpc = ctx.outputs.project.value.vpc;
 
     const describeMountTargetsCommand = new DescribeMountTargetsCommand({
-      FileSystemId: ecsServiceWithStorage.persistentStorage.fileSystem.id
+      FileSystemId: ecsServiceWithStorage.persistentStorage.fileSystem.id,
     });
-    const { MountTargets } = await ctx.clients.efs.send(describeMountTargetsCommand);
-
-    assert.ok(MountTargets && MountTargets.length > 0, 'Mount targets should exist');
-
-    const describeSecurityGroupsCommand = new DescribeMountTargetSecurityGroupsCommand({
-      MountTargetId: MountTargets[0].MountTargetId
-    });
-    const { SecurityGroups } = await ctx.clients.efs.send(describeSecurityGroupsCommand);
-
-    assert.ok(SecurityGroups && SecurityGroups.length > 0, 'Security groups should be attached to mount target');
-
-    const ec2DescribeSecurityGroupsCommand = new DescribeSecurityGroupsCommand({
-      GroupIds: SecurityGroups
-    });
-    const { SecurityGroups: securityGroupDetails } = await ctx.clients.ec2.send(ec2DescribeSecurityGroupsCommand);
-
-    assert.ok(securityGroupDetails && securityGroupDetails.length > 0, 'Security group details should be available');
-
-    const efsSecurityGroup = securityGroupDetails.find(sg =>
-      sg.IpPermissions?.some(permission =>
-        permission.FromPort === 2049 &&
-        permission.ToPort === 2049 &&
-        permission.IpProtocol === 'tcp'
-      )
+    const { MountTargets } = await ctx.clients.efs.send(
+      describeMountTargetsCommand,
     );
 
-    assert.ok(efsSecurityGroup, 'EFS security group with port 2049 should exist');
-    assert.ok(efsSecurityGroup.GroupName?.includes(ecsServiceWithStorage.name),
-      'Security group should have correct name');
+    assert.ok(
+      MountTargets && MountTargets.length > 0,
+      'Mount targets should exist',
+    );
 
-    const nfsRule = efsSecurityGroup.IpPermissions?.find(p => p.FromPort === 2049);
-    assert.ok(nfsRule?.IpRanges?.some(range => range.CidrIp === vpc.vpc.cidrBlock),
-      'Security group should allow access from VPC CIDR');
+    const describeSecurityGroupsCommand =
+      new DescribeMountTargetSecurityGroupsCommand({
+        MountTargetId: MountTargets[0].MountTargetId,
+      });
+    const { SecurityGroups } = await ctx.clients.efs.send(
+      describeSecurityGroupsCommand,
+    );
+
+    assert.ok(
+      SecurityGroups && SecurityGroups.length > 0,
+      'Security groups should be attached to mount target',
+    );
+
+    const ec2DescribeSecurityGroupsCommand = new DescribeSecurityGroupsCommand({
+      GroupIds: SecurityGroups,
+    });
+    const { SecurityGroups: securityGroupDetails } = await ctx.clients.ec2.send(
+      ec2DescribeSecurityGroupsCommand,
+    );
+
+    assert.ok(
+      securityGroupDetails && securityGroupDetails.length > 0,
+      'Security group details should be available',
+    );
+
+    const efsSecurityGroup = securityGroupDetails.find(sg =>
+      sg.IpPermissions?.some(
+        permission =>
+          permission.FromPort === 2049 &&
+          permission.ToPort === 2049 &&
+          permission.IpProtocol === 'tcp',
+      ),
+    );
+
+    assert.ok(
+      efsSecurityGroup,
+      'EFS security group with port 2049 should exist',
+    );
+    assert.ok(
+      efsSecurityGroup.GroupName?.includes(ecsServiceWithStorage.name),
+      'Security group should have correct name',
+    );
+
+    const nfsRule = efsSecurityGroup.IpPermissions?.find(
+      p => p.FromPort === 2049,
+    );
+    assert.ok(
+      nfsRule?.IpRanges?.some(range => range.CidrIp === vpc.vpc.cidrBlock),
+      'Security group should allow access from VPC CIDR',
+    );
   });
 
   it('should create mount targets in all private subnets', async () => {
@@ -81,18 +122,23 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
     const vpc = ctx.outputs.project.value.vpc;
 
     const command = new DescribeMountTargetsCommand({
-      FileSystemId: ecsServiceWithStorage.persistentStorage.fileSystem.id
+      FileSystemId: ecsServiceWithStorage.persistentStorage.fileSystem.id,
     });
     const { MountTargets } = await ctx.clients.efs.send(command);
 
     assert.ok(MountTargets, 'Mount targets should exist');
 
     const privateSubnetIds = vpc.privateSubnetIds;
-    assert.strictEqual(MountTargets.length, privateSubnetIds.length,
-      'Should have a mount target for each private subnet');
+    assert.strictEqual(
+      MountTargets.length,
+      privateSubnetIds.length,
+      'Should have a mount target for each private subnet',
+    );
 
     privateSubnetIds.forEach((subnetId: any) => {
-      const hasTarget = MountTargets.some(target => target.SubnetId === subnetId);
+      const hasTarget = MountTargets.some(
+        target => target.SubnetId === subnetId,
+      );
       assert.ok(hasTarget, `Subnet ${subnetId} should have a mount target`);
     });
   });
@@ -104,20 +150,39 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
     assert.ok(accessPoint, 'Access point should be created');
 
     const command = new DescribeAccessPointsCommand({
-      AccessPointId: accessPoint.id
+      AccessPointId: accessPoint.id,
     });
     const { AccessPoints } = await ctx.clients.efs.send(command);
 
-    assert.ok(AccessPoints && AccessPoints.length === 1, 'Access point should exist');
+    assert.ok(
+      AccessPoints && AccessPoints.length === 1,
+      'Access point should exist',
+    );
     const ap = AccessPoints[0];
 
     assert.strictEqual(ap.PosixUser?.Uid, 1000, 'Should use UID 1000');
     assert.strictEqual(ap.PosixUser?.Gid, 1000, 'Should use GID 1000');
 
-    assert.strictEqual(ap.RootDirectory?.Path, '/data', 'Root directory should be /data');
-    assert.strictEqual(ap.RootDirectory?.CreationInfo?.OwnerUid, 1000, 'Owner UID should be 1000');
-    assert.strictEqual(ap.RootDirectory?.CreationInfo.OwnerGid, 1000, 'Owner GID should be 1000');
-    assert.strictEqual(ap.RootDirectory?.CreationInfo.Permissions, '0755', 'Permissions should be 0755');
+    assert.strictEqual(
+      ap.RootDirectory?.Path,
+      '/data',
+      'Root directory should be /data',
+    );
+    assert.strictEqual(
+      ap.RootDirectory?.CreationInfo?.OwnerUid,
+      1000,
+      'Owner UID should be 1000',
+    );
+    assert.strictEqual(
+      ap.RootDirectory?.CreationInfo.OwnerGid,
+      1000,
+      'Owner GID should be 1000',
+    );
+    assert.strictEqual(
+      ap.RootDirectory?.CreationInfo.Permissions,
+      '0755',
+      'Permissions should be 0755',
+    );
   });
 
   it('should configure task definition with EFS volumes', async () => {
@@ -125,36 +190,71 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
 
     const taskDef = ecsServiceWithStorage.taskDefinition;
 
-    assert.ok(taskDef.volumes && taskDef.volumes.length > 0, 'Task definition should have volumes');
+    assert.ok(
+      taskDef.volumes && taskDef.volumes.length > 0,
+      'Task definition should have volumes',
+    );
 
     const efsVolume = taskDef.volumes[0];
-    assert.ok(efsVolume.efsVolumeConfiguration, 'Volume should have EFS configuration');
-    assert.strictEqual(efsVolume.efsVolumeConfiguration.fileSystemId,
+    assert.ok(
+      efsVolume.efsVolumeConfiguration,
+      'Volume should have EFS configuration',
+    );
+    assert.strictEqual(
+      efsVolume.efsVolumeConfiguration.fileSystemId,
       ecsServiceWithStorage.persistentStorage.fileSystem.id,
-      'Volume should reference correct EFS file system');
-    assert.strictEqual(efsVolume.efsVolumeConfiguration.transitEncryption, 'ENABLED',
-      'Transit encryption should be enabled');
-    assert.strictEqual(efsVolume.efsVolumeConfiguration.authorizationConfig.accessPointId,
+      'Volume should reference correct EFS file system',
+    );
+    assert.strictEqual(
+      efsVolume.efsVolumeConfiguration.transitEncryption,
+      'ENABLED',
+      'Transit encryption should be enabled',
+    );
+    assert.strictEqual(
+      efsVolume.efsVolumeConfiguration.authorizationConfig.accessPointId,
       ecsServiceWithStorage.persistentStorage.accessPoint.id,
-      'Should use correct access point');
-    assert.strictEqual(efsVolume.efsVolumeConfiguration.authorizationConfig.iam, 'ENABLED',
-      'IAM authorization should be enabled');
+      'Should use correct access point',
+    );
+    assert.strictEqual(
+      efsVolume.efsVolumeConfiguration.authorizationConfig.iam,
+      'ENABLED',
+      'IAM authorization should be enabled',
+    );
   });
 
   it('should configure container with mount points', async () => {
     const ecsServiceWithStorage = ctx.outputs.ecsServiceWithStorage.value;
 
-    const containerDefs = JSON.parse(ecsServiceWithStorage.taskDefinition.containerDefinitions);
-    assert.ok(containerDefs && containerDefs.length > 0, 'Container definitions should exist');
+    const containerDefs = JSON.parse(
+      ecsServiceWithStorage.taskDefinition.containerDefinitions,
+    );
+    assert.ok(
+      containerDefs && containerDefs.length > 0,
+      'Container definitions should exist',
+    );
 
     const container = containerDefs[0];
-    assert.ok(container.mountPoints && container.mountPoints.length > 0,
-      'Container should have mount points');
+    assert.ok(
+      container.mountPoints && container.mountPoints.length > 0,
+      'Container should have mount points',
+    );
 
     const mountPoint = container.mountPoints[0];
-    assert.strictEqual(mountPoint.sourceVolume, 'data-volume', 'Should reference correct volume');
-    assert.strictEqual(mountPoint.containerPath, '/data', 'Should mount at correct container path');
-    assert.strictEqual(mountPoint.readOnly, false, 'Should be writeable by default');
+    assert.strictEqual(
+      mountPoint.sourceVolume,
+      'data-volume',
+      'Should reference correct volume',
+    );
+    assert.strictEqual(
+      mountPoint.containerPath,
+      '/data',
+      'Should mount at correct container path',
+    );
+    assert.strictEqual(
+      mountPoint.readOnly,
+      false,
+      'Should be writeable by default',
+    );
   });
 
   it('should successfully write to and read from EFS volume', async () => {
@@ -165,14 +265,14 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
 
     const listCommand = new ListTasksCommand({
       cluster: clusterName,
-      family: ecsServiceWithStorage.taskDefinition.family
+      family: ecsServiceWithStorage.taskDefinition.family,
     });
     const { taskArns } = await ctx.clients.ecs.send(listCommand);
     assert.ok(taskArns && taskArns.length > 0, 'Task should be running');
 
     const describeTasksCommand = new DescribeTasksCommand({
       cluster: clusterName,
-      tasks: taskArns
+      tasks: taskArns,
     });
     const { tasks = [] } = await ctx.clients.ecs.send(describeTasksCommand);
     const [task] = tasks;
@@ -185,46 +285,59 @@ export function testEcsServiceWithStorage(ctx: EcsTestContext) {
 
     const describeStreamsCommand = new DescribeLogStreamsCommand({
       logGroupName: ecsServiceWithStorage.logGroup.name,
-      logStreamNamePrefix: `ecs/test-container/${taskId}`
+      logStreamNamePrefix: `ecs/test-container/${taskId}`,
     });
 
-    return backOff(async () => {
-      const { logStreams = [] } = await logsClient.send(describeStreamsCommand);
-      assert.ok(logStreams.length > 0, 'Log stream should exist');
+    return backOff(
+      async () => {
+        const { logStreams = [] } = await logsClient.send(
+          describeStreamsCommand,
+        );
+        assert.ok(logStreams.length > 0, 'Log stream should exist');
 
-      const getLogsCommand = new GetLogEventsCommand({
-        logGroupName: ecsServiceWithStorage.logGroup.name,
-        logStreamName: logStreams[0].logStreamName,
-        startFromHead: true
-      });
+        const getLogsCommand = new GetLogEventsCommand({
+          logGroupName: ecsServiceWithStorage.logGroup.name,
+          logStreamName: logStreams[0].logStreamName,
+          startFromHead: true,
+        });
 
-      const { events } = await logsClient.send(getLogsCommand);
-      assert.ok(events && events.length > 0, 'Log events should exist');
+        const { events } = await logsClient.send(getLogsCommand);
+        assert.ok(events && events.length > 0, 'Log events should exist');
 
-      const logContent = events.map(e => e.message).join('\n');
-      assert.ok(
-        logContent.includes('Successfully wrote to and read from EFS volume'),
-        'Logs should indicate successful EFS operation'
-      );
-      assert.ok(
-        !logContent.includes('Failed to write to or read from EFS volume'),
-        'Logs should not contain failure messages'
-      );
-    }, {
-      ...ctx.config.exponentialBackOffConfig,
-      numOfAttempts: 8,
-    });
+        const logContent = events.map(e => e.message).join('\n');
+        assert.ok(
+          logContent.includes('Successfully wrote to and read from EFS volume'),
+          'Logs should indicate successful EFS operation',
+        );
+        assert.ok(
+          !logContent.includes('Failed to write to or read from EFS volume'),
+          'Logs should not contain failure messages',
+        );
+      },
+      {
+        ...ctx.config.exponentialBackOffConfig,
+        numOfAttempts: 8,
+      },
+    );
   });
 
   it('should create ECS service when empty volumes array argument is passed', async () => {
     const ecsService = ctx.outputs.ecsServiceWithEmptyVolumes.value;
     assert.ok(ecsService, 'ECS Service should be defined');
-    assert.strictEqual(ecsService.service.persistentStorage, undefined, 'Service should not have persistent storage defined');
+    assert.strictEqual(
+      ecsService.service.persistentStorage,
+      undefined,
+      'Service should not have persistent storage defined',
+    );
   });
 
   it('should create ECS service when empty output volumes array argument is passed', async () => {
     const ecsService = ctx.outputs.ecsServiceWithOutputEmptyVolumes.value;
     assert.ok(ecsService, 'ECS Service should be defined');
-    assert.strictEqual(ecsService.service.persistentStorage, undefined, 'Service should not have persistent storage defined');
+    assert.strictEqual(
+      ecsService.service.persistentStorage,
+      undefined,
+      'Service should not have persistent storage defined',
+    );
   });
 }

--- a/tests/ecs-service/service-discovery.test.ts
+++ b/tests/ecs-service/service-discovery.test.ts
@@ -2,7 +2,10 @@ import { it } from 'node:test';
 import * as assert from 'node:assert';
 import { backOff } from 'exponential-backoff';
 import { EcsTestContext } from './test-context';
-import { GetNamespaceCommand, ListInstancesCommand } from '@aws-sdk/client-servicediscovery';
+import {
+  GetNamespaceCommand,
+  ListInstancesCommand,
+} from '@aws-sdk/client-servicediscovery';
 
 export function testEcsServiceWithServiceDiscovery(ctx: EcsTestContext) {
   it('should create a private DNS namespace for service discovery', async () => {
@@ -15,8 +18,16 @@ export function testEcsServiceWithServiceDiscovery(ctx: EcsTestContext) {
     const { Namespace } = await ctx.clients.sd.send(command);
 
     assert.ok(Namespace, 'Namespace should exist');
-    assert.strictEqual(Namespace.Type, 'DNS_PRIVATE', 'Should be a private DNS namespace');
-    assert.strictEqual(Namespace.Name, ecsWithDiscovery.name, 'Namespace name should match service name');
+    assert.strictEqual(
+      Namespace.Type,
+      'DNS_PRIVATE',
+      'Should be a private DNS namespace',
+    );
+    assert.strictEqual(
+      Namespace.Name,
+      ecsWithDiscovery.name,
+      'Namespace name should match service name',
+    );
   });
 
   it('should register the service in service discovery', async () => {
@@ -29,8 +40,10 @@ export function testEcsServiceWithServiceDiscovery(ctx: EcsTestContext) {
       const command = new ListInstancesCommand({ ServiceId: serviceId });
       const { Instances } = await ctx.clients.sd.send(command);
 
-      assert.ok(Instances && Instances.length > 0, 'Service should have registered instances');
+      assert.ok(
+        Instances && Instances.length > 0,
+        'Service should have registered instances',
+      );
     }, ctx.config.exponentialBackOffConfig);
   });
-
 }

--- a/tests/ecs-service/test-context.ts
+++ b/tests/ecs-service/test-context.ts
@@ -27,4 +27,7 @@ interface AwsContext {
   };
 }
 
-export interface EcsTestContext extends ConfigContext, PulumiProgramContext, AwsContext { };
+export interface EcsTestContext
+  extends ConfigContext,
+    PulumiProgramContext,
+    AwsContext {}

--- a/tests/otel/index.test.ts
+++ b/tests/otel/index.test.ts
@@ -5,62 +5,59 @@ import { testOtelCollectorConfigBuilderValidation } from './validation.test';
 
 const awsRegion = 'us-west-2';
 const prometheusNamespace = 'test-namespace';
-const prometheusWriteEndpoint = 'https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345/api/v1/remote_write';
+const prometheusWriteEndpoint =
+  'https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-12345/api/v1/remote_write';
 
 const defaultMemoryLimiterConfig = {
   check_interval: '1s',
   limit_percentage: 80,
-  spike_limit_percentage: 15
+  spike_limit_percentage: 15,
 };
 const defaultBatchConfig = {
   send_batch_size: 8192,
   send_batch_max_size: 10000,
-  timeout: '5s'
+  timeout: '5s',
 };
 
 describe('OtelCollectorConfigBuilder', () => {
-  it(
-    'should generate minimal configuration with OTLP receiver and debug exporter',
-    () => {
-      const result = new OtelCollectorConfigBuilder()
-        .withOTLPReceiver(['http'])
-        .withDebug()
-        .build();
+  it('should generate minimal configuration with OTLP receiver and debug exporter', () => {
+    const result = new OtelCollectorConfigBuilder()
+      .withOTLPReceiver(['http'])
+      .withDebug()
+      .build();
 
-      const expected = {
-        receivers: {
-          otlp: {
-            protocols: {
-              http: { endpoint: '0.0.0.0:4318' }
-            }
-          }
+    const expected = {
+      receivers: {
+        otlp: {
+          protocols: {
+            http: { endpoint: '0.0.0.0:4318' },
+          },
         },
-        processors: {},
-        exporters: {
-          debug: { verbosity: 'detailed' }
-        },
-        extensions: {},
-        service: { pipelines: {} }
-      };
+      },
+      processors: {},
+      exporters: {
+        debug: { verbosity: 'detailed' },
+      },
+      extensions: {},
+      service: { pipelines: {} },
+    };
 
-      assert.deepStrictEqual(result, expected);
-    }
-  );
+    assert.deepStrictEqual(result, expected);
+  });
 
   it('should configure batch processor', () => {
     const result = new OtelCollectorConfigBuilder()
       .withBatchProcessor()
       .build();
 
-
     const expected = {
       receivers: {},
       processors: {
-        batch: defaultBatchConfig
+        batch: defaultBatchConfig,
       },
       exporters: {},
       extensions: {},
-      service: { pipelines: {} }
+      service: { pipelines: {} },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -71,15 +68,14 @@ describe('OtelCollectorConfigBuilder', () => {
       .withMemoryLimiterProcessor()
       .build();
 
-
     const expected = {
       receivers: {},
       processors: {
-        memory_limiter: defaultMemoryLimiterConfig
+        memory_limiter: defaultMemoryLimiterConfig,
       },
       exporters: {},
       extensions: {},
-      service: { pipelines: {} }
+      service: { pipelines: {} },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -93,7 +89,7 @@ describe('OtelCollectorConfigBuilder', () => {
     assert.deepStrictEqual(result.processors.batch, {
       send_batch_size: 5000,
       send_batch_max_size: 8000,
-      timeout: '10s'
+      timeout: '10s',
     });
   });
 
@@ -105,7 +101,7 @@ describe('OtelCollectorConfigBuilder', () => {
     assert.deepStrictEqual(result.processors.memory_limiter, {
       check_interval: '3s',
       limit_percentage: 70,
-      spike_limit_percentage: 15
+      spike_limit_percentage: 15,
     });
   });
 
@@ -121,19 +117,19 @@ describe('OtelCollectorConfigBuilder', () => {
         prometheusremotewrite: {
           namespace: prometheusNamespace,
           endpoint: prometheusWriteEndpoint,
-          auth: { authenticator: 'sigv4auth' }
-        }
+          auth: { authenticator: 'sigv4auth' },
+        },
       },
       extensions: {
         sigv4auth: {
           region: awsRegion,
-          service: 'aps'
-        }
+          service: 'aps',
+        },
       },
       service: {
         extensions: ['sigv4auth'],
-        pipelines: {}
-      }
+        pipelines: {},
+      },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -148,10 +144,10 @@ describe('OtelCollectorConfigBuilder', () => {
       receivers: {},
       processors: {},
       exporters: {
-        awsxray: { region: awsRegion }
+        awsxray: { region: awsRegion },
       },
       extensions: {},
-      service: { pipelines: {} }
+      service: { pipelines: {} },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -167,12 +163,12 @@ describe('OtelCollectorConfigBuilder', () => {
       processors: {},
       exporters: {},
       extensions: {
-        health_check: { endpoint: '0.0.0.0:13133' }
+        health_check: { endpoint: '0.0.0.0:13133' },
       },
       service: {
         extensions: ['health_check'],
-        pipelines: {}
-      }
+        pipelines: {},
+      },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -188,12 +184,12 @@ describe('OtelCollectorConfigBuilder', () => {
       processors: {},
       exporters: {},
       extensions: {
-        pprof: { endpoint: '0.0.0.0:1777' }
+        pprof: { endpoint: '0.0.0.0:1777' },
       },
       service: {
         extensions: ['pprof'],
-        pipelines: {}
-      }
+        pipelines: {},
+      },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -206,15 +202,11 @@ describe('OtelCollectorConfigBuilder', () => {
       .withMemoryLimiterProcessor()
       .withAWSXRayExporter(awsRegion)
       .withDebug()
-      .withMetricsPipeline(
-        ['otlp'],
-        ['memory_limiter', 'batch'],
-        ['debug']
-      )
+      .withMetricsPipeline(['otlp'], ['memory_limiter', 'batch'], ['debug'])
       .withTracesPipeline(
         ['otlp'],
         ['memory_limiter', 'batch'],
-        ['awsxray', 'debug']
+        ['awsxray', 'debug'],
       )
       .build();
 
@@ -222,17 +214,17 @@ describe('OtelCollectorConfigBuilder', () => {
       receivers: {
         otlp: {
           protocols: {
-            http: { endpoint: '0.0.0.0:4318' }
-          }
-        }
+            http: { endpoint: '0.0.0.0:4318' },
+          },
+        },
       },
       processors: {
         batch: defaultBatchConfig,
-        memory_limiter: defaultMemoryLimiterConfig
+        memory_limiter: defaultMemoryLimiterConfig,
       },
       exporters: {
         awsxray: { region: awsRegion },
-        debug: { verbosity: 'detailed' }
+        debug: { verbosity: 'detailed' },
       },
       extensions: {},
       service: {
@@ -240,15 +232,15 @@ describe('OtelCollectorConfigBuilder', () => {
           metrics: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['debug']
+            exporters: ['debug'],
           },
           traces: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['awsxray', 'debug']
-          }
-        }
-      }
+            exporters: ['awsxray', 'debug'],
+          },
+        },
+      },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -269,33 +261,32 @@ describe('OtelCollectorConfigBuilder', () => {
       .withDefault(prometheusNamespace, prometheusWriteEndpoint, awsRegion)
       .build();
 
-
     const expected = {
       receivers: {
         otlp: {
           protocols: {
-            http: { endpoint: '0.0.0.0:4318' }
-          }
-        }
+            http: { endpoint: '0.0.0.0:4318' },
+          },
+        },
       },
       processors: {
         batch: defaultBatchConfig,
-        memory_limiter: defaultMemoryLimiterConfig
+        memory_limiter: defaultMemoryLimiterConfig,
       },
       exporters: {
         prometheusremotewrite: {
           namespace: prometheusNamespace,
           endpoint: prometheusWriteEndpoint,
-          auth: { authenticator: 'sigv4auth' }
+          auth: { authenticator: 'sigv4auth' },
         },
-        awsxray: { region: awsRegion }
+        awsxray: { region: awsRegion },
       },
       extensions: {
         sigv4auth: {
           region: awsRegion,
-          service: 'aps'
+          service: 'aps',
         },
-        health_check: { endpoint: '0.0.0.0:13133' }
+        health_check: { endpoint: '0.0.0.0:13133' },
       },
       service: {
         extensions: ['sigv4auth', 'health_check'],
@@ -303,19 +294,19 @@ describe('OtelCollectorConfigBuilder', () => {
           metrics: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['prometheusremotewrite']
+            exporters: ['prometheusremotewrite'],
           },
           traces: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['awsxray']
-          }
+            exporters: ['awsxray'],
+          },
         },
         telemetry: {
           logs: { level: 'error' },
-          metrics: { level: 'basic' }
-        }
-      }
+          metrics: { level: 'basic' },
+        },
+      },
     };
 
     assert.deepStrictEqual(result, expected);
@@ -335,44 +326,43 @@ describe('OtelCollectorConfigBuilder', () => {
       .withMetricsPipeline(
         ['otlp'],
         ['memory_limiter', 'batch'],
-        ['prometheusremotewrite', 'debug']
+        ['prometheusremotewrite', 'debug'],
       )
       .withTracesPipeline(
         ['otlp'],
         ['memory_limiter', 'batch'],
-        ['awsxray', 'debug']
+        ['awsxray', 'debug'],
       )
       .build();
-
 
     const expected = {
       receivers: {
         otlp: {
           protocols: {
-            http: { endpoint: '0.0.0.0:4318' }
-          }
-        }
+            http: { endpoint: '0.0.0.0:4318' },
+          },
+        },
       },
       processors: {
         batch: defaultBatchConfig,
-        memory_limiter: defaultMemoryLimiterConfig
+        memory_limiter: defaultMemoryLimiterConfig,
       },
       exporters: {
         prometheusremotewrite: {
           namespace: prometheusNamespace,
           endpoint: prometheusWriteEndpoint,
-          auth: { authenticator: 'sigv4auth' }
+          auth: { authenticator: 'sigv4auth' },
         },
         awsxray: { region: awsRegion },
-        debug: { verbosity: 'detailed' }
+        debug: { verbosity: 'detailed' },
       },
       extensions: {
         sigv4auth: {
           region: awsRegion,
-          service: 'aps'
+          service: 'aps',
         },
         health_check: { endpoint: '0.0.0.0:13133' },
-        pprof: { endpoint: '0.0.0.0:1777' }
+        pprof: { endpoint: '0.0.0.0:1777' },
       },
       service: {
         extensions: ['sigv4auth', 'health_check', 'pprof'],
@@ -380,19 +370,19 @@ describe('OtelCollectorConfigBuilder', () => {
           metrics: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['prometheusremotewrite', 'debug']
+            exporters: ['prometheusremotewrite', 'debug'],
           },
           traces: {
             receivers: ['otlp'],
             processors: ['memory_limiter', 'batch'],
-            exporters: ['awsxray', 'debug']
-          }
+            exporters: ['awsxray', 'debug'],
+          },
         },
         telemetry: {
           logs: { level: 'error' },
-          metrics: { level: 'basic' }
-        }
-      }
+          metrics: { level: 'basic' },
+        },
+      },
     };
 
     assert.deepStrictEqual(result, expected);

--- a/tests/otel/validation.test.ts
+++ b/tests/otel/validation.test.ts
@@ -4,127 +4,138 @@ import { OtelCollectorConfigBuilder } from '../../src/v2/otel/config';
 
 export function testOtelCollectorConfigBuilderValidation() {
   it('should throw error when no OTLP receiver protocols are provided', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver([])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder().withOTLPReceiver([]).build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: 'At least one OTLP receiver protocol should be provided'
+      message: 'At least one OTLP receiver protocol should be provided',
     });
   });
 
   it('should throw error when unsupported OTLP receiver protocol is provided', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      // @ts-expect-error - Passing invalid protocol to test runtime error
-      .withOTLPReceiver(['invalid'])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        // @ts-expect-error - Passing invalid protocol to test runtime error
+        .withOTLPReceiver(['invalid'])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: 'OTLP receiver protocol invalid is not supported'
+      message: 'OTLP receiver protocol invalid is not supported',
     });
   });
 
   it('should throw error when metrics pipeline references undefined receiver', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withMetricsPipeline(['otlp'], [], [])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withMetricsPipeline(['otlp'], [], [])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Receiver 'otlp' is used in metrics pipeline but not defined"
+      message: "Receiver 'otlp' is used in metrics pipeline but not defined",
     });
   });
 
   it('should throw error when metrics pipeline references undefined processor', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withMetricsPipeline(['otlp'], ['batch'], [])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withMetricsPipeline(['otlp'], ['batch'], [])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Processor 'batch' is used in metrics pipeline but not defined"
+      message: "Processor 'batch' is used in metrics pipeline but not defined",
     });
   });
 
   it('should throw error when metrics pipeline references undefined exporter', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withBatchProcessor()
-      .withMetricsPipeline(['otlp'], ['batch'], ['debug'])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withBatchProcessor()
+        .withMetricsPipeline(['otlp'], ['batch'], ['debug'])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Exporter 'debug' is used in metrics pipeline but not defined"
+      message: "Exporter 'debug' is used in metrics pipeline but not defined",
     });
   });
 
   it('should throw error when traces pipeline references undefined receiver', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withTracesPipeline(['otlp'], [], [])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withTracesPipeline(['otlp'], [], [])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Receiver 'otlp' is used in traces pipeline but not defined"
+      message: "Receiver 'otlp' is used in traces pipeline but not defined",
     });
   });
 
   it('should throw error when traces pipeline references undefined processor', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withTracesPipeline(['otlp'], ['memory_limiter'], [])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withTracesPipeline(['otlp'], ['memory_limiter'], [])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Processor 'memory_limiter' is used in traces pipeline but not defined"
+      message:
+        "Processor 'memory_limiter' is used in traces pipeline but not defined",
     });
   });
 
   it('should throw error when traces pipeline references undefined exporter', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withMemoryLimiterProcessor()
-      .withTracesPipeline(['otlp'], ['memory_limiter'], ['awsxray'])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withMemoryLimiterProcessor()
+        .withTracesPipeline(['otlp'], ['memory_limiter'], ['awsxray'])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: "Exporter 'awsxray' is used in traces pipeline but not defined"
+      message: "Exporter 'awsxray' is used in traces pipeline but not defined",
     });
   });
 
   it('should throw error when memory_limiter is not the first processor in traces pipeline ', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withMemoryLimiterProcessor()
-      .withBatchProcessor()
-      .withDebug()
-      .withTracesPipeline(['otlp'], ['batch', 'memory_limiter'], ['debug'])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withMemoryLimiterProcessor()
+        .withBatchProcessor()
+        .withDebug()
+        .withTracesPipeline(['otlp'], ['batch', 'memory_limiter'], ['debug'])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: 'memory_limiter processor is not the first processor in the traces pipeline.'
+      message:
+        'memory_limiter processor is not the first processor in the traces pipeline.',
     });
   });
 
   it('should throw error when memory_limiter is not the first processor in metrics pipeline ', () => {
-    const createInvalidConfig = () => new OtelCollectorConfigBuilder()
-      .withOTLPReceiver(['http'])
-      .withMemoryLimiterProcessor()
-      .withBatchProcessor()
-      .withDebug()
-      .withMetricsPipeline(['otlp'], ['batch', 'memory_limiter'], ['debug'])
-      .build();
+    const createInvalidConfig = () =>
+      new OtelCollectorConfigBuilder()
+        .withOTLPReceiver(['http'])
+        .withMemoryLimiterProcessor()
+        .withBatchProcessor()
+        .withDebug()
+        .withMetricsPipeline(['otlp'], ['batch', 'memory_limiter'], ['debug'])
+        .build();
 
     assert.throws(createInvalidConfig, {
       name: 'Error',
-      message: 'memory_limiter processor is not the first processor in the metrics pipeline.'
+      message:
+        'memory_limiter processor is not the first processor in the metrics pipeline.',
     });
   });
 }

--- a/tests/web-server/index.test.ts
+++ b/tests/web-server/index.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, before, after } from 'node:test';
 import * as assert from 'node:assert';
 import { InlineProgramArgs } from '@pulumi/pulumi/automation';
-import { DescribeServicesCommand, DescribeTaskDefinitionCommand, ECSClient } from '@aws-sdk/client-ecs';
+import {
+  DescribeServicesCommand,
+  DescribeTaskDefinitionCommand,
+  ECSClient,
+} from '@aws-sdk/client-ecs';
 import { EC2Client, DescribeSecurityGroupsCommand } from '@aws-sdk/client-ec2';
 import {
   ElasticLoadBalancingV2Client,
   DescribeLoadBalancersCommand,
   DescribeTargetGroupsCommand,
-  DescribeListenersCommand
+  DescribeListenersCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import { ACMClient } from '@aws-sdk/client-acm';
 import { Route53Client } from '@aws-sdk/client-route-53';
@@ -21,7 +25,7 @@ import * as config from './infrastructure/config';
 const programArgs: InlineProgramArgs = {
   stackName: 'dev',
   projectName: 'icb-test-web-server',
-  program: () => import('./infrastructure')
+  program: () => import('./infrastructure'),
 };
 
 class NonRetryableError extends Error {
@@ -41,9 +45,9 @@ describe('Web server component deployment', () => {
       ec2: new EC2Client({ region }),
       elb: new ElasticLoadBalancingV2Client({ region }),
       acm: new ACMClient({ region }),
-      route53: new Route53Client({ region })
-    }
-  }
+      route53: new Route53Client({ region }),
+    },
+  };
 
   before(async () => {
     ctx.outputs = await automation.deploy(programArgs);
@@ -57,7 +61,7 @@ describe('Web server component deployment', () => {
     assert.strictEqual(
       webServer.name,
       ctx.config.webServerName,
-      'WebServer should have correct name'
+      'WebServer should have correct name',
     );
   });
 
@@ -66,21 +70,29 @@ describe('Web server component deployment', () => {
     assert.ok(webServer.lb.lb, 'Load balancer should be defined');
 
     const command = new DescribeLoadBalancersCommand({
-      LoadBalancerArns: [webServer.lb.lb.arn]
+      LoadBalancerArns: [webServer.lb.lb.arn],
     });
     const response = await ctx.clients.elb.send(command);
     const [lb] = response.LoadBalancers ?? [];
 
     assert.ok(lb, 'Load balancer should exist in AWS');
-    assert.strictEqual(lb.Scheme, 'internet-facing', 'Load balancer should be internet-facing');
-    assert.strictEqual(lb.Type, 'application', 'Load balancer should be an application load balancer');
+    assert.strictEqual(
+      lb.Scheme,
+      'internet-facing',
+      'Load balancer should be internet-facing',
+    );
+    assert.strictEqual(
+      lb.Type,
+      'application',
+      'Load balancer should be an application load balancer',
+    );
   });
 
   it('should create target group with correct health check path', async () => {
     const webServer = ctx.outputs.webServer.value;
 
     const command = new DescribeTargetGroupsCommand({
-      TargetGroupArns: [webServer.lb.targetGroup.arn]
+      TargetGroupArns: [webServer.lb.targetGroup.arn],
     });
 
     const response = await ctx.clients.elb.send(command);
@@ -90,7 +102,7 @@ describe('Web server component deployment', () => {
     assert.strictEqual(
       tg.HealthCheckPath,
       ctx.config.healthCheckPath,
-      'Target group should have correct health check path'
+      'Target group should have correct health check path',
     );
   });
 
@@ -98,7 +110,7 @@ describe('Web server component deployment', () => {
     const webServer = ctx.outputs.webServer.value;
 
     const command = new DescribeListenersCommand({
-      ListenerArns: [webServer.lb.httpListener.arn]
+      ListenerArns: [webServer.lb.httpListener.arn],
     });
 
     const response = await ctx.clients.elb.send(command);
@@ -112,7 +124,7 @@ describe('Web server component deployment', () => {
     const webServer = ctx.outputs.webServer.value;
 
     const lbSgCommand = new DescribeSecurityGroupsCommand({
-      GroupIds: [webServer.lb.securityGroup.id]
+      GroupIds: [webServer.lb.securityGroup.id],
     });
 
     const lbSgResponse = await ctx.clients.ec2.send(lbSgCommand);
@@ -124,32 +136,34 @@ describe('Web server component deployment', () => {
     });
     assert.ok(
       hasHttpTrafficPermission,
-      'LB security group should allow HTTP traffic'
+      'LB security group should allow HTTP traffic',
     );
     const hasTlsTrafficPermission = lbSg.IpPermissions?.some(permission => {
       return permission.FromPort === 443 && permission.ToPort === 443;
-    })
+    });
     assert.ok(
       hasTlsTrafficPermission,
-      'LB security group should allow HTTPS traffic'
+      'LB security group should allow HTTPS traffic',
     );
 
     const serviceSgCommand = new DescribeSecurityGroupsCommand({
-      GroupIds: [webServer.serviceSecurityGroup.id]
+      GroupIds: [webServer.serviceSecurityGroup.id],
     });
 
     const serviceSgResponse = await ctx.clients.ec2.send(serviceSgCommand);
     const [serviceSg] = serviceSgResponse.SecurityGroups ?? [];
 
     assert.ok(serviceSg, 'Service security group should exist');
-    const allowsIncomingLbTraffic = serviceSg.IpPermissions?.some(permission => {
-      return permission.UserIdGroupPairs?.some(group => {
-        return group.GroupId === webServer.lb.securityGroup.id;
-      });
-    });
+    const allowsIncomingLbTraffic = serviceSg.IpPermissions?.some(
+      permission => {
+        return permission.UserIdGroupPairs?.some(group => {
+          return group.GroupId === webServer.lb.securityGroup.id;
+        });
+      },
+    );
     assert.ok(
       allowsIncomingLbTraffic,
-      'Service security group should allow traffic from load balancer'
+      'Service security group should allow traffic from load balancer',
     );
   });
 
@@ -158,14 +172,16 @@ describe('Web server component deployment', () => {
     const { services } = await ctx.clients.ecs.send(
       new DescribeServicesCommand({
         cluster: webServer.ecsConfig.cluster.name,
-        services: [webServer.service.name]
-      })
+        services: [webServer.service.name],
+      }),
     );
     assert.ok(services && services.length > 0, 'Service should exist');
     const [service] = services;
 
     const { taskDefinition } = await ctx.clients.ecs.send(
-      new DescribeTaskDefinitionCommand({ taskDefinition: service.taskDefinition })
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: service.taskDefinition,
+      }),
     );
     assert.ok(taskDefinition, 'Task definition should exist');
 
@@ -173,7 +189,11 @@ describe('Web server component deployment', () => {
     const initContainer = containerDefs?.find(({ name }) => name === 'init');
 
     assert.ok(initContainer, 'Init container should be in task definition');
-    assert.strictEqual(initContainer.essential, false, 'Init container should not be essential');
+    assert.strictEqual(
+      initContainer.essential,
+      false,
+      'Init container should not be essential',
+    );
   });
 
   it('should include sidecar container in the task definition', async () => {
@@ -181,22 +201,33 @@ describe('Web server component deployment', () => {
     const { services } = await ctx.clients.ecs.send(
       new DescribeServicesCommand({
         cluster: webServer.ecsConfig.cluster.name,
-        services: [webServer.service.name]
-      })
+        services: [webServer.service.name],
+      }),
     );
     assert.ok(services && services.length > 0, 'Service should exist');
     const [service] = services;
 
     const { taskDefinition } = await ctx.clients.ecs.send(
-      new DescribeTaskDefinitionCommand({ taskDefinition: service.taskDefinition })
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: service.taskDefinition,
+      }),
     );
     assert.ok(taskDefinition, 'Task definition should exist');
 
     const containerDefs = taskDefinition.containerDefinitions;
-    const sidecarContainer = containerDefs?.find(({ name }) => name === 'sidecar');
+    const sidecarContainer = containerDefs?.find(
+      ({ name }) => name === 'sidecar',
+    );
 
-    assert.ok(sidecarContainer, 'Sidecar container should be in the task definition');
-    assert.strictEqual(sidecarContainer.essential, true, 'Sidecar should be marked as essential');
+    assert.ok(
+      sidecarContainer,
+      'Sidecar container should be in the task definition',
+    );
+    assert.strictEqual(
+      sidecarContainer.essential,
+      true,
+      'Sidecar should be marked as essential',
+    );
   });
 
   it('should include OpenTelemetry collector when configured', async () => {
@@ -206,14 +237,16 @@ describe('Web server component deployment', () => {
     const { services } = await ctx.clients.ecs.send(
       new DescribeServicesCommand({
         cluster: webServer.ecsConfig.cluster.name,
-        services: [webServer.service.name]
-      })
+        services: [webServer.service.name],
+      }),
     );
     assert.ok(services && services.length > 0, 'Service should exist');
     const [service] = services;
 
     const { taskDefinition } = await ctx.clients.ecs.send(
-      new DescribeTaskDefinitionCommand({ taskDefinition: service.taskDefinition })
+      new DescribeTaskDefinitionCommand({
+        taskDefinition: service.taskDefinition,
+      }),
     );
     assert.ok(taskDefinition, 'Task definition should exist');
 
@@ -222,24 +255,40 @@ describe('Web server component deployment', () => {
       return containerDef.name === otelCollector.container.name;
     });
 
-    assert.ok(collectorContainer, 'OTel collector container should be in task definition');
+    assert.ok(
+      collectorContainer,
+      'OTel collector container should be in task definition',
+    );
 
     const hasConfigVolume = collectorContainer.mountPoints?.some(mountPoint => {
       return mountPoint.sourceVolume === otelCollector.configVolume;
     });
-    assert.ok(hasConfigVolume, 'OTel collector should have config volume mounted');
+    assert.ok(
+      hasConfigVolume,
+      'OTel collector should have config volume mounted',
+    );
 
     const configContainer = containerDefs?.find(containerDef => {
-      return containerDef.name === otelCollector.configContainer.name
+      return containerDef.name === otelCollector.configContainer.name;
     });
 
-    assert.ok(configContainer, 'OTel config container should be in task definition');
-    assert.strictEqual(configContainer.essential, false, 'Config container should not be essential');
+    assert.ok(
+      configContainer,
+      'OTel config container should be in task definition',
+    );
+    assert.strictEqual(
+      configContainer.essential,
+      false,
+      'Config container should not be essential',
+    );
 
     const hasOtelVolume = taskDefinition.volumes?.some(
-      volume => volume.name === otelCollector.configVolume
+      volume => volume.name === otelCollector.configVolume,
     );
-    assert.ok(hasOtelVolume, 'Task definition should include OTel config volume');
+    assert.ok(
+      hasOtelVolume,
+      'Task definition should include OTel config volume',
+    );
   });
 
   it('should receive 200 status code from the healthcheck endpoint', () => {
@@ -252,24 +301,29 @@ describe('Web server component deployment', () => {
 
     const webServerUrl = `http://${webServerLbDns}`;
 
-    return backOff(async () => {
-      const response = await request(`${webServerUrl}${ctx.config.healthCheckPath}`);
-      if (response.statusCode === status.NOT_FOUND) {
-        throw new NonRetryableError('Healthcheck endpoint not found');
-      }
+    return backOff(
+      async () => {
+        const response = await request(
+          `${webServerUrl}${ctx.config.healthCheckPath}`,
+        );
+        if (response.statusCode === status.NOT_FOUND) {
+          throw new NonRetryableError('Healthcheck endpoint not found');
+        }
 
-      assert.strictEqual(
-        response.statusCode,
-        status.OK,
-        `Expected status code 200 but got ${response.statusCode}`
-      );
-    }, {
-      retry: error => !(error instanceof NonRetryableError),
-      delayFirstAttempt: true,
-      numOfAttempts: 10,
-      startingDelay: 1000,
-      timeMultiple: 2,
-      jitter: 'full'
-    });
+        assert.strictEqual(
+          response.statusCode,
+          status.OK,
+          `Expected status code 200 but got ${response.statusCode}`,
+        );
+      },
+      {
+        retry: error => !(error instanceof NonRetryableError),
+        delayFirstAttempt: true,
+        numOfAttempts: 10,
+        startingDelay: 1000,
+        timeMultiple: 2,
+        jitter: 'full',
+      },
+    );
   });
 });

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -10,7 +10,7 @@ const init = {
   name: 'init',
   image: 'busybox:latest',
   essential: false,
-  command: ['sh', '-c', 'echo "Init container running" && exit 0']
+  command: ['sh', '-c', 'echo "Init container running" && exit 0'],
 };
 const sidecar = {
   name: 'sidecar',
@@ -18,14 +18,17 @@ const sidecar = {
   essential: true,
   command: ['sh', '-c', 'echo "Sidecar running" && sleep infinity'],
   healthCheck: {
-    command: ["CMD-SHELL", "echo healthy || exit 1"],
+    command: ['CMD-SHELL', 'echo healthy || exit 1'],
     interval: 30,
     timeout: 5,
     retries: 3,
-    startPeriod: 10
-  }
+    startPeriod: 10,
+  },
 };
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(webServerName, stackName)
+const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(
+  webServerName,
+  stackName,
+)
   .withOTLPReceiver()
   .withDebug()
   .withMetricsPipeline(['otlp'], [], ['debug'])
@@ -33,7 +36,7 @@ const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(webServerNa
 
 const cluster = new aws.ecs.Cluster(`${webServerName}-cluster`, {
   name: `${webServerName}-cluster-${stackName}`,
-  tags
+  tags,
 });
 
 const webServer = new studion.WebServerBuilder(webServerName)
@@ -42,7 +45,7 @@ const webServer = new studion.WebServerBuilder(webServerName)
     cluster,
     desiredCount: 1,
     size: 'small',
-    autoscaling: { enabled: false }
+    autoscaling: { enabled: false },
   })
   .withInitContainer(init)
   .withSidecarContainer(sidecar)

--- a/tests/web-server/test-context.ts
+++ b/tests/web-server/test-context.ts
@@ -25,4 +25,7 @@ interface AwsContext {
   };
 }
 
-export interface WebServerTestContext extends ConfigContext, PulumiProgramContext, AwsContext { };
+export interface WebServerTestContext
+  extends ConfigContext,
+    PulumiProgramContext,
+    AwsContext {}


### PR DESCRIPTION
Apply the `format` script to unify codebase formatting with Prettier.