### PR TITLE
fix: Set docker user to one defined in EFS AP config

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release": "release-it --only-version",
     "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=none -r ts-node/register tests/**[!build]/index.test.ts",
     "test:build": "npm run build && tstyche build",
-    "prepare": "husky"
+    "prepare": "husky && npm run build"
   },
   "prettier": "@studion/prettier-config",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "release": "release-it --only-version",
     "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=none -r ts-node/register tests/**[!build]/index.test.ts",
     "test:build": "npm run build && tstyche build",
-    "prepare": "husky && npm run build"
+    "prepare": "husky"
   },
   "prettier": "@studion/prettier-config",
   "dependencies": {

--- a/src/components/ecs-service.ts
+++ b/src/components/ecs-service.ts
@@ -451,6 +451,7 @@ export class EcsService extends pulumi.ComponentResource {
                       sourceVolume: mountPoint.sourceVolume,
                       readOnly: mountPoint.readOnly ?? false,
                     })),
+                    user: `${FIRST_POSIX_NON_ROOT_USER.userId}:${FIRST_POSIX_NON_ROOT_USER.groupId}`,
                   }),
                   logConfiguration: {
                     logDriver: 'awslogs',


### PR DESCRIPTION
Issue: Mongo fails to deploy on ECS with startup error `chown: changing ownership of '/data/db': Operation not permitted`

This PR:
- [x] Sets docker user to the one used in EFS AP
	- This is in order to make docker run the same user as defined in AP and avoid issues with access rights