### PR TITLE
test: add CloudFront tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.782.0",
         "@aws-sdk/client-application-auto-scaling": "^3.758.0",
+        "@aws-sdk/client-cloudfront": "^3.948.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.767.0",
         "@aws-sdk/client-ec2": "^3.767.0",
         "@aws-sdk/client-ecs": "^3.766.0",
@@ -42,6 +43,7 @@
         "husky": "^9.1.7",
         "ioredis": "^5.8.1",
         "lint-staged": "^16.1.2",
+        "mime": "^4.1.0",
         "nanospinner": "^1.2.2",
         "pathe": "^2.0.3",
         "prettier": "^3.4.2",
@@ -732,6 +734,579 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.971.0.tgz",
+      "integrity": "sha512-kLtm5jaWVXaej8a6WbFd1iDMFXy19WakT8b/hk3gHtcm6KfnTGX1K/YwpNGfuTzUze16ZjQrbIen/loM+2U2KA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/credential-provider-node": "3.971.0",
+        "@aws-sdk/middleware-host-header": "3.969.0",
+        "@aws-sdk/middleware-logger": "3.969.0",
+        "@aws-sdk/middleware-recursion-detection": "3.969.0",
+        "@aws-sdk/middleware-user-agent": "3.970.0",
+        "@aws-sdk/region-config-resolver": "3.969.0",
+        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/util-endpoints": "3.970.0",
+        "@aws-sdk/util-user-agent-browser": "3.969.0",
+        "@aws-sdk/util-user-agent-node": "3.971.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.20.6",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.7",
+        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.22",
+        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-stream": "^4.5.10",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sso": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.971.0.tgz",
+      "integrity": "sha512-Xx+w6DQqJxDdymYyIxyKJnRzPvVJ4e/Aw0czO7aC9L/iraaV7AG8QtRe93OGW6aoHSh72CIiinnpJJfLsQqP4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/middleware-host-header": "3.969.0",
+        "@aws-sdk/middleware-logger": "3.969.0",
+        "@aws-sdk/middleware-recursion-detection": "3.969.0",
+        "@aws-sdk/middleware-user-agent": "3.970.0",
+        "@aws-sdk/region-config-resolver": "3.969.0",
+        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/util-endpoints": "3.970.0",
+        "@aws-sdk/util-user-agent-browser": "3.969.0",
+        "@aws-sdk/util-user-agent-node": "3.971.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.20.6",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.7",
+        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.22",
+        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/core": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.970.0.tgz",
+      "integrity": "sha512-klpzObldOq8HXzDjDlY6K8rMhYZU6mXRz6P9F9N+tWnjoYFfeBMra8wYApydElTUYQKP1O7RLHwH1OKFfKcqIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/xml-builder": "3.969.0",
+        "@smithy/core": "^3.20.6",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.970.0.tgz",
+      "integrity": "sha512-rtVzXzEtAfZBfh+lq3DAvRar4c3jyptweOAJR2DweyXx71QSMY+O879hjpMwES7jl07a3O1zlnFIDo4KP/96kQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.970.0.tgz",
+      "integrity": "sha512-CjDbWL7JxjLc9ZxQilMusWSw05yRvUJKRpz59IxDpWUnSMHC9JMMUUkOy5Izk8UAtzi6gupRWArp4NG4labt9Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.971.0.tgz",
+      "integrity": "sha512-c0TGJG4xyfTZz3SInXfGU8i5iOFRrLmy4Bo7lMyH+IpngohYMYGYl61omXqf2zdwMbDv+YJ9AviQTcCaEUKi8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/credential-provider-env": "3.970.0",
+        "@aws-sdk/credential-provider-http": "3.970.0",
+        "@aws-sdk/credential-provider-login": "3.971.0",
+        "@aws-sdk/credential-provider-process": "3.970.0",
+        "@aws-sdk/credential-provider-sso": "3.971.0",
+        "@aws-sdk/credential-provider-web-identity": "3.971.0",
+        "@aws-sdk/nested-clients": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.971.0.tgz",
+      "integrity": "sha512-yhbzmDOsk0RXD3rTPhZra4AWVnVAC4nFWbTp+sUty1hrOPurUmhuz8bjpLqYTHGnlMbJp+UqkQONhS2+2LzW2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/nested-clients": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.971.0.tgz",
+      "integrity": "sha512-epUJBAKivtJqalnEBRsYIULKYV063o/5mXNJshZfyvkAgNIzc27CmmKRXTN4zaNOZg8g/UprFp25BGsi19x3nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.970.0",
+        "@aws-sdk/credential-provider-http": "3.970.0",
+        "@aws-sdk/credential-provider-ini": "3.971.0",
+        "@aws-sdk/credential-provider-process": "3.970.0",
+        "@aws-sdk/credential-provider-sso": "3.971.0",
+        "@aws-sdk/credential-provider-web-identity": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.970.0.tgz",
+      "integrity": "sha512-0XeT8OaT9iMA62DFV9+m6mZfJhrD0WNKf4IvsIpj2Z7XbaYfz3CoDDvNoALf3rPY9NzyMHgDxOspmqdvXP00mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.971.0.tgz",
+      "integrity": "sha512-dY0hMQ7dLVPQNJ8GyqXADxa9w5wNfmukgQniLxGVn+dMRx3YLViMp5ZpTSQpFhCWNF0oKQrYAI5cHhUJU1hETw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.971.0",
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/token-providers": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.971.0.tgz",
+      "integrity": "sha512-F1AwfNLr7H52T640LNON/h34YDiMuIqW/ZreGzhRR6vnFGaSPtNSKAKB2ssAMkLM8EVg8MjEAYD3NCUiEo+t/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/nested-clients": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.969.0.tgz",
+      "integrity": "sha512-AWa4rVsAfBR4xqm7pybQ8sUNJYnjyP/bJjfAw34qPuh3M9XrfGbAHG0aiAfQGrBnmS28jlO6Kz69o+c6PRw1dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.969.0.tgz",
+      "integrity": "sha512-xwrxfip7Y2iTtCMJ+iifN1E1XMOuhxIHY9DreMCvgdl4r7+48x2S1bCYPWH3eNY85/7CapBWdJ8cerpEl12sQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.969.0.tgz",
+      "integrity": "sha512-2r3PuNquU3CcS1Am4vn/KHFwLi8QFjMdA/R+CRDXT4AFO/0qxevF/YStW3gAKntQIgWgQV8ZdEtKAoJvLI4UWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.970.0.tgz",
+      "integrity": "sha512-dnSJGGUGSFGEX2NzvjwSefH+hmZQ347AwbLhAsi0cdnISSge+pcGfOFrJt2XfBIypwFe27chQhlfuf/gWdzpZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/util-endpoints": "3.970.0",
+        "@smithy/core": "^3.20.6",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.971.0.tgz",
+      "integrity": "sha512-TWaILL8GyYlhGrxxnmbkazM4QsXatwQgoWUvo251FXmUOsiXDFDVX3hoGIfB3CaJhV2pJPfebHUNJtY6TjZ11g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/middleware-host-header": "3.969.0",
+        "@aws-sdk/middleware-logger": "3.969.0",
+        "@aws-sdk/middleware-recursion-detection": "3.969.0",
+        "@aws-sdk/middleware-user-agent": "3.970.0",
+        "@aws-sdk/region-config-resolver": "3.969.0",
+        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/util-endpoints": "3.970.0",
+        "@aws-sdk/util-user-agent-browser": "3.969.0",
+        "@aws-sdk/util-user-agent-node": "3.971.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.20.6",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.7",
+        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.22",
+        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.969.0.tgz",
+      "integrity": "sha512-scj9OXqKpcjJ4jsFLtqYWz3IaNvNOQTFFvEY8XMJXTv+3qF5I7/x9SJtKzTRJEBF3spjzBUYPtGFbs9sj4fisQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/token-providers": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.971.0.tgz",
+      "integrity": "sha512-4hKGWZbmuDdONMJV0HJ+9jwTDb0zLfKxcCLx2GEnBY31Gt9GeyIQ+DZ97Bb++0voawj6pnZToFikXTyrEq2x+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.970.0",
+        "@aws-sdk/nested-clients": "3.971.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.969.0.tgz",
+      "integrity": "sha512-7IIzM5TdiXn+VtgPdVLjmE6uUBUtnga0f4RiSEI1WW10RPuNvZ9U+pL3SwDiRDAdoGrOF9tSLJOFZmfuwYuVYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.970.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.970.0.tgz",
+      "integrity": "sha512-TZNZqFcMUtjvhZoZRtpEGQAdULYiy6rcGiXAbLU7e9LSpIYlRqpLa207oMNfgbzlL2PnHko+eVg8rajDiSOYCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.969.0.tgz",
+      "integrity": "sha512-bpJGjuKmFr0rA6UKUCmN8D19HQFMLXMx5hKBXqBlPFdalMhxJSjcxzX9DbQh0Fn6bJtxCguFmRGOBdQqNOt49g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/types": "^4.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.971.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.971.0.tgz",
+      "integrity": "sha512-Eygjo9mFzQYjbGY3MYO6CsIhnTwAMd3WmuFalCykqEmj2r5zf0leWrhPaqvA5P68V5JdGfPYgj7vhNOd6CtRBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.970.0",
+        "@aws-sdk/types": "3.969.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.969.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.969.0.tgz",
+      "integrity": "sha512-BSe4Lx/qdRQQdX8cSSI7Et20vqBspzAjBy8ZmXVoyLkol3y4sXBXzn+BiLtR+oh60ExQn6o2DU4QjdOZbXaKIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.12.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
       "version": "3.767.0",
@@ -1545,25 +2120,25 @@
       "license": "MIT"
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.970.0.tgz",
-      "integrity": "sha512-FGMxkjt3dB5fI4GfU1Qc9mIHSbPKGSFMV5hQN2i3apkYYAehLPfTFaIw6YwpFlA3er9AA/WB4MmKE4yk0C+htA==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.972.0.tgz",
+      "integrity": "sha512-2Bla8ElNZopJtnvtAPCdwWusmJhHFcdTlYUbZjfmT5qZIu3uaIlrJrY0+azGR3quhIXKxB8rUuo689ohe3VYvQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/credential-provider-node": "3.970.0",
-        "@aws-sdk/middleware-host-header": "3.969.0",
-        "@aws-sdk/middleware-logger": "3.969.0",
-        "@aws-sdk/middleware-recursion-detection": "3.969.0",
-        "@aws-sdk/middleware-user-agent": "3.970.0",
-        "@aws-sdk/region-config-resolver": "3.969.0",
-        "@aws-sdk/types": "3.969.0",
-        "@aws-sdk/util-endpoints": "3.970.0",
-        "@aws-sdk/util-user-agent-browser": "3.969.0",
-        "@aws-sdk/util-user-agent-node": "3.970.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/credential-provider-node": "3.972.0",
+        "@aws-sdk/middleware-host-header": "3.972.0",
+        "@aws-sdk/middleware-logger": "3.972.0",
+        "@aws-sdk/middleware-recursion-detection": "3.972.0",
+        "@aws-sdk/middleware-user-agent": "3.972.0",
+        "@aws-sdk/region-config-resolver": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "3.972.0",
+        "@aws-sdk/util-user-agent-node": "3.972.0",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.20.6",
         "@smithy/fetch-http-handler": "^5.3.9",
@@ -1597,24 +2172,24 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sso": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.970.0.tgz",
-      "integrity": "sha512-ArmgnOsSCXN5VyIvZb4kSP5hpqlRRHolrMtKQ/0N8Hw4MTb7/IeYHSZzVPNzzkuX6gn5Aj8txoUnDPM8O7pc9g==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.972.0.tgz",
+      "integrity": "sha512-5qw6qLiRE4SUiz0hWy878dSR13tSVhbTWhsvFT8mGHe37NRRiaobm5MA2sWD0deRAuO98djSiV+dhWXa1xIFNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/middleware-host-header": "3.969.0",
-        "@aws-sdk/middleware-logger": "3.969.0",
-        "@aws-sdk/middleware-recursion-detection": "3.969.0",
-        "@aws-sdk/middleware-user-agent": "3.970.0",
-        "@aws-sdk/region-config-resolver": "3.969.0",
-        "@aws-sdk/types": "3.969.0",
-        "@aws-sdk/util-endpoints": "3.970.0",
-        "@aws-sdk/util-user-agent-browser": "3.969.0",
-        "@aws-sdk/util-user-agent-node": "3.970.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/middleware-host-header": "3.972.0",
+        "@aws-sdk/middleware-logger": "3.972.0",
+        "@aws-sdk/middleware-recursion-detection": "3.972.0",
+        "@aws-sdk/middleware-user-agent": "3.972.0",
+        "@aws-sdk/region-config-resolver": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "3.972.0",
+        "@aws-sdk/util-user-agent-node": "3.972.0",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.20.6",
         "@smithy/fetch-http-handler": "^5.3.9",
@@ -1647,14 +2222,14 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/core": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.970.0.tgz",
-      "integrity": "sha512-klpzObldOq8HXzDjDlY6K8rMhYZU6mXRz6P9F9N+tWnjoYFfeBMra8wYApydElTUYQKP1O7RLHwH1OKFfKcqIA==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.972.0.tgz",
+      "integrity": "sha512-nEeUW2M9F+xdIaD98F5MBcQ4ITtykj3yKbgFZ6J0JtL3bq+Z90szQ6Yy8H/BLPYXTs3V4n9ifnBo8cprRDiE6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
-        "@aws-sdk/xml-builder": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/xml-builder": "3.972.0",
         "@smithy/core": "^3.20.6",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
@@ -1672,14 +2247,14 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.970.0.tgz",
-      "integrity": "sha512-rtVzXzEtAfZBfh+lq3DAvRar4c3jyptweOAJR2DweyXx71QSMY+O879hjpMwES7jl07a3O1zlnFIDo4KP/96kQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.0.tgz",
+      "integrity": "sha512-kKHoNv+maHlPQOAhYamhap0PObd16SAb3jwaY0KYgNTiSbeXlbGUZPLioo9oA3wU10zItJzx83ClU7d7h40luA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -1689,14 +2264,14 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.970.0.tgz",
-      "integrity": "sha512-CjDbWL7JxjLc9ZxQilMusWSw05yRvUJKRpz59IxDpWUnSMHC9JMMUUkOy5Izk8UAtzi6gupRWArp4NG4labt9Q==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.0.tgz",
+      "integrity": "sha512-xzEi81L7I5jGUbpmqEHCe7zZr54hCABdj4H+3LzktHYuovV/oqnvoDdvZpGFR0e/KAw1+PL38NbGrpG30j6qlA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/property-provider": "^4.2.8",
@@ -1711,21 +2286,21 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.970.0.tgz",
-      "integrity": "sha512-L5R1hN1FY/xCmH65DOYMXl8zqCFiAq0bAq8tJZU32mGjIl1GzGeOkeDa9c461d81o7gsQeYzXyqFD3vXEbJ+kQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.0.tgz",
+      "integrity": "sha512-ruhAMceUIq2aknFd3jhWxmO0P0Efab5efjyIXOkI9i80g+zDY5VekeSxfqRKStEEJSKSCHDLQuOu0BnAn4Rzew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/credential-provider-env": "3.970.0",
-        "@aws-sdk/credential-provider-http": "3.970.0",
-        "@aws-sdk/credential-provider-login": "3.970.0",
-        "@aws-sdk/credential-provider-process": "3.970.0",
-        "@aws-sdk/credential-provider-sso": "3.970.0",
-        "@aws-sdk/credential-provider-web-identity": "3.970.0",
-        "@aws-sdk/nested-clients": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/credential-provider-env": "3.972.0",
+        "@aws-sdk/credential-provider-http": "3.972.0",
+        "@aws-sdk/credential-provider-login": "3.972.0",
+        "@aws-sdk/credential-provider-process": "3.972.0",
+        "@aws-sdk/credential-provider-sso": "3.972.0",
+        "@aws-sdk/credential-provider-web-identity": "3.972.0",
+        "@aws-sdk/nested-clients": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -1737,15 +2312,15 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.970.0.tgz",
-      "integrity": "sha512-C+1dcLr+p2E+9hbHyvrQTZ46Kj4vC2RoP6N935GEukHQa637ZjXs8VlyHJ2xTvbvwwLZQNiu56Cx7o/OFOqw1A==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.0.tgz",
+      "integrity": "sha512-SsrsFJsEYAJHO4N/r2P0aK6o8si6f1lprR+Ej8J731XJqTckSGs/HFHcbxOyW/iKt+LNUvZa59/VlJmjhF4bEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/nested-clients": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/nested-clients": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -1757,19 +2332,19 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.970.0.tgz",
-      "integrity": "sha512-nMM0eeVuiLtw1taLRQ+H/H5Qp11rva8ILrzAQXSvlbDeVmbc7d8EeW5Q2xnCJu+3U+2JNZ1uxqIL22pB2sLEMA==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.0.tgz",
+      "integrity": "sha512-wwJDpEGl6+sOygic8QKu0OHVB8SiodqF1fr5jvUlSFfS6tJss/E9vBc2aFjl7zI6KpAIYfIzIgM006lRrZtWCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.970.0",
-        "@aws-sdk/credential-provider-http": "3.970.0",
-        "@aws-sdk/credential-provider-ini": "3.970.0",
-        "@aws-sdk/credential-provider-process": "3.970.0",
-        "@aws-sdk/credential-provider-sso": "3.970.0",
-        "@aws-sdk/credential-provider-web-identity": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/credential-provider-env": "3.972.0",
+        "@aws-sdk/credential-provider-http": "3.972.0",
+        "@aws-sdk/credential-provider-ini": "3.972.0",
+        "@aws-sdk/credential-provider-process": "3.972.0",
+        "@aws-sdk/credential-provider-sso": "3.972.0",
+        "@aws-sdk/credential-provider-web-identity": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -1781,14 +2356,14 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.970.0.tgz",
-      "integrity": "sha512-0XeT8OaT9iMA62DFV9+m6mZfJhrD0WNKf4IvsIpj2Z7XbaYfz3CoDDvNoALf3rPY9NzyMHgDxOspmqdvXP00mw==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.0.tgz",
+      "integrity": "sha512-nmzYhamLDJ8K+v3zWck79IaKMc350xZnWsf/GeaXO6E3MewSzd3lYkTiMi7lEp3/UwDm9NHfPguoPm+mhlSWQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -1799,16 +2374,16 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.970.0.tgz",
-      "integrity": "sha512-ROb+Aijw8nzkB14Nh2XRH861++SeTZykUzk427y8YtgTLxjAOjgDTchDUFW2Fx6GFWkSjqJ3sY7SZyb33IqyFw==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.0.tgz",
+      "integrity": "sha512-6mYyfk1SrMZ15cH9T53yAF4YSnvq4yU1Xlgm3nqV1gZVQzmF5kr4t/F3BU3ygbvzi4uSwWxG3I3TYYS5eMlAyg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.970.0",
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/token-providers": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/client-sso": "3.972.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/token-providers": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -1819,15 +2394,15 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.970.0.tgz",
-      "integrity": "sha512-r7tnYJJg+B6QvnsRHSW5vDol+ks6n+5jBZdCFdGyK63hjcMRMqHx59zEH8O47UR1PFv5hS2Q3uGz6HXvVtP40Q==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.0.tgz",
+      "integrity": "sha512-vsJXBGL8H54kz4T6do3p5elATj5d1izVGUXMluRJntm9/I0be/zUYtdd4oDTM2kSUmd4Zhyw3fMQ9lw7CVhd4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/nested-clients": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/nested-clients": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -1838,13 +2413,13 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.969.0.tgz",
-      "integrity": "sha512-AWa4rVsAfBR4xqm7pybQ8sUNJYnjyP/bJjfAw34qPuh3M9XrfGbAHG0aiAfQGrBnmS28jlO6Kz69o+c6PRw1dw==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.0.tgz",
+      "integrity": "sha512-3eztFI6F9/eHtkIaWKN3nT+PM+eQ6p1MALDuNshFk323ixuCZzOOVT8oUqtZa30Z6dycNXJwhlIq7NhUVFfimw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -1854,13 +2429,13 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.969.0.tgz",
-      "integrity": "sha512-xwrxfip7Y2iTtCMJ+iifN1E1XMOuhxIHY9DreMCvgdl4r7+48x2S1bCYPWH3eNY85/7CapBWdJ8cerpEl12sQQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.0.tgz",
+      "integrity": "sha512-ZvdyVRwzK+ra31v1pQrgbqR/KsLD+wwJjHgko6JfoKUBIcEfAwJzQKO6HspHxdHWTVUz6MgvwskheR/TTYZl2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -1869,13 +2444,13 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.969.0.tgz",
-      "integrity": "sha512-2r3PuNquU3CcS1Am4vn/KHFwLi8QFjMdA/R+CRDXT4AFO/0qxevF/YStW3gAKntQIgWgQV8ZdEtKAoJvLI4UWg==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.0.tgz",
+      "integrity": "sha512-F2SmUeO+S6l1h6dydNet3BQIk173uAkcfU1HDkw/bUdRLAnh15D3HP9vCZ7oCPBNcdEICbXYDmx0BR9rRUHGlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -1886,15 +2461,15 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.970.0.tgz",
-      "integrity": "sha512-dnSJGGUGSFGEX2NzvjwSefH+hmZQ347AwbLhAsi0cdnISSge+pcGfOFrJt2XfBIypwFe27chQhlfuf/gWdzpZg==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.0.tgz",
+      "integrity": "sha512-kFHQm2OCBJCzGWRafgdWHGFjitUXY/OxXngymcX4l8CiyiNDZB27HDDBg2yLj3OUJc4z4fexLMmP8r9vgag19g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
-        "@aws-sdk/util-endpoints": "3.970.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
         "@smithy/core": "^3.20.6",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -1905,24 +2480,24 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.970.0.tgz",
-      "integrity": "sha512-RIl8s4DCa31MXtRFw23iU90OqEoWuwQxiZOZshzsPtjyrunhHFjyZJEqb+vuQcYd1o22SMaYa3lPJRp64OH35Q==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.972.0.tgz",
+      "integrity": "sha512-QGlbnuGzSQJVG6bR9Qw6G0Blh6abFR4VxNa61ttMbzy9jt28xmk2iGtrYLrQPlCCPhY6enHqjTWm3n3LOb0wAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/middleware-host-header": "3.969.0",
-        "@aws-sdk/middleware-logger": "3.969.0",
-        "@aws-sdk/middleware-recursion-detection": "3.969.0",
-        "@aws-sdk/middleware-user-agent": "3.970.0",
-        "@aws-sdk/region-config-resolver": "3.969.0",
-        "@aws-sdk/types": "3.969.0",
-        "@aws-sdk/util-endpoints": "3.970.0",
-        "@aws-sdk/util-user-agent-browser": "3.969.0",
-        "@aws-sdk/util-user-agent-node": "3.970.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/middleware-host-header": "3.972.0",
+        "@aws-sdk/middleware-logger": "3.972.0",
+        "@aws-sdk/middleware-recursion-detection": "3.972.0",
+        "@aws-sdk/middleware-user-agent": "3.972.0",
+        "@aws-sdk/region-config-resolver": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/util-endpoints": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "3.972.0",
+        "@aws-sdk/util-user-agent-node": "3.972.0",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.20.6",
         "@smithy/fetch-http-handler": "^5.3.9",
@@ -1955,13 +2530,13 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.969.0.tgz",
-      "integrity": "sha512-scj9OXqKpcjJ4jsFLtqYWz3IaNvNOQTFFvEY8XMJXTv+3qF5I7/x9SJtKzTRJEBF3spjzBUYPtGFbs9sj4fisQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.0.tgz",
+      "integrity": "sha512-JyOf+R/6vJW8OEVFCAyzEOn2reri/Q+L0z9zx4JQSKWvTmJ1qeFO25sOm8VIfB8URKhfGRTQF30pfYaH2zxt/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -1972,15 +2547,15 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/token-providers": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.970.0.tgz",
-      "integrity": "sha512-YO8KgJecxHIFMhfoP880q51VXFL9V1ELywK5yzVEqzyrwqoG93IUmnTygBUylQrfkbH+QqS0FxEdgwpP3fcwoQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.972.0.tgz",
+      "integrity": "sha512-kWlXG+y5nZhgXGEtb72Je+EvqepBPs8E3vZse//1PYLWs2speFqbGE/ywCXmzEJgHgVqSB/u/lqBvs5WlYmSqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.970.0",
-        "@aws-sdk/nested-clients": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/core": "3.972.0",
+        "@aws-sdk/nested-clients": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -1991,9 +2566,9 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/types": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.969.0.tgz",
-      "integrity": "sha512-7IIzM5TdiXn+VtgPdVLjmE6uUBUtnga0f4RiSEI1WW10RPuNvZ9U+pL3SwDiRDAdoGrOF9tSLJOFZmfuwYuVYQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
+      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2005,13 +2580,13 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.970.0.tgz",
-      "integrity": "sha512-TZNZqFcMUtjvhZoZRtpEGQAdULYiy6rcGiXAbLU7e9LSpIYlRqpLa207oMNfgbzlL2PnHko+eVg8rajDiSOYCg==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.972.0.tgz",
+      "integrity": "sha512-6JHsl1V/a1ZW8D8AFfd4R52fwZPnZ5H4U6DS8m/bWT8qad72NvbOFAC7U2cDtFs2TShqUO3TEiX/EJibtY3ijg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-endpoints": "^3.2.8",
@@ -2022,27 +2597,27 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.969.0.tgz",
-      "integrity": "sha512-bpJGjuKmFr0rA6UKUCmN8D19HQFMLXMx5hKBXqBlPFdalMhxJSjcxzX9DbQh0Fn6bJtxCguFmRGOBdQqNOt49g==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.0.tgz",
+      "integrity": "sha512-eOLdkQyoRbDgioTS3Orr7iVsVEutJyMZxvyZ6WAF95IrF0kfWx5Rd/KXnfbnG/VKa2CvjZiitWfouLzfVEyvJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/types": "^4.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.970.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.970.0.tgz",
-      "integrity": "sha512-TNQpwIVD6SxMwkD+QKnaujKVyXy5ljN3O3jrI7nCHJ3GlJu5xJrd8yuBnanYCcrn3e2zwdfOh4d4zJAZvvIvVw==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.0.tgz",
+      "integrity": "sha512-GOy+AiSrE9kGiojiwlZvVVSXwylu4+fmP0MJfvras/MwP09RB/YtQuOVR1E0fKQc6OMwaTNBjgAbOEhxuWFbAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.970.0",
-        "@aws-sdk/types": "3.969.0",
+        "@aws-sdk/middleware-user-agent": "3.972.0",
+        "@aws-sdk/types": "3.972.0",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -2060,9 +2635,9 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.969.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.969.0.tgz",
-      "integrity": "sha512-BSe4Lx/qdRQQdX8cSSI7Et20vqBspzAjBy8ZmXVoyLkol3y4sXBXzn+BiLtR+oh60ExQn6o2DU4QjdOZbXaKIQ==",
+      "version": "3.972.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.0.tgz",
+      "integrity": "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6875,6 +7450,30 @@
         "mime": "^2.0.0"
       }
     },
+    "node_modules/@pulumi/aws-v7/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@pulumi/aws/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/@pulumi/awsx": {
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/@pulumi/awsx/-/awsx-2.22.0.tgz",
@@ -6926,6 +7525,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@pulumi/pulumi": "^3.142.0"
+      }
+    },
+    "node_modules/@pulumi/awsx-v3/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@pulumi/awsx/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/@pulumi/docker": {
@@ -7353,9 +7976,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.6.tgz",
-      "integrity": "sha512-BpAffW1mIyRZongoKBbh3RgHG+JDHJek/8hjA/9LnPunM+ejorO6axkxCgwxCe4K//g/JdPeR9vROHDYr/hfnQ==",
+      "version": "3.20.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.7.tgz",
+      "integrity": "sha512-aO7jmh3CtrmPsIJxUwYIzI5WVlMK8BMCPQ4D4nTzqTqBhbzvxHNzBMGcEg13yg/z9R2Qsz49NUFl0F0lVbTVFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.9",
@@ -7535,12 +8158,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.7.tgz",
-      "integrity": "sha512-SCmhUG1UwtnEhF5Sxd8qk7bJwkj1BpFzFlHkXqKCEmDPLrRjJyTGM0EhqT7XBtDaDJjCfjRJQodgZcKDR843qg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.8.tgz",
+      "integrity": "sha512-TV44qwB/T0OMMzjIuI+JeS0ort3bvlPJ8XIH0MSlGADraXpZqmyND27ueuAL3E14optleADWqtd7dUgc2w+qhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.6",
+        "@smithy/core": "^3.20.7",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -7554,15 +8177,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.23.tgz",
-      "integrity": "sha512-lLEmkQj7I7oKfvZ1wsnToGJouLOtfkMXDKRA1Hi6F+mMp5O1N8GcVWmVeNgTtgZtd0OTXDTI2vpVQmeutydGew==",
+      "version": "4.4.24",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.24.tgz",
+      "integrity": "sha512-yiUY1UvnbUFfP5izoKLtfxDSTRv724YRRwyiC/5HYY6vdsVDcDOXKSXmkJl/Hovcxt5r+8tZEUAdrOaCJwrl9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.9",
         "@smithy/types": "^4.12.0",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -7729,13 +8352,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.8.tgz",
-      "integrity": "sha512-wcr3UEL26k7lLoyf9eVDZoD1nNY3Fa1gbNuOXvfxvVWLGkOVW+RYZgUUp/bXHryJfycIOQnBq9o1JAE00ax8HQ==",
+      "version": "4.10.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.9.tgz",
+      "integrity": "sha512-Je0EvGXVJ0Vrrr2lsubq43JGRIluJ/hX17aN/W/A0WfE+JpoMdI8kwk2t9F0zTX9232sJDGcoH4zZre6m6f/sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.6",
-        "@smithy/middleware-endpoint": "^4.4.7",
+        "@smithy/core": "^3.20.7",
+        "@smithy/middleware-endpoint": "^4.4.8",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -7836,13 +8459,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.22.tgz",
-      "integrity": "sha512-O2WXr6ZRqPnbyoepb7pKcLt1QL6uRfFzGYJ9sGb5hMJQi7v/4RjRmCQa9mNjA0YiXqsc5lBmLXqJPhjM1Vjv5A==",
+      "version": "4.3.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.23.tgz",
+      "integrity": "sha512-mMg+r/qDfjfF/0psMbV4zd7F/i+rpyp7Hjh0Wry7eY15UnzTEId+xmQTGDU8IdZtDfbGQxuWNfgBZKBj+WuYbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.9",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -7851,16 +8474,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.25",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.25.tgz",
-      "integrity": "sha512-7uMhppVNRbgNIpyUBVRfjGHxygP85wpXalRvn9DvUlCx4qgy1AB/uxOPSiDx/jFyrwD3/BypQhx1JK7f3yxrAw==",
+      "version": "4.2.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.26.tgz",
+      "integrity": "sha512-EQqe/WkbCinah0h1lMWh9ICl0Ob4lyl20/10WTB35SC9vDQfD8zWsOT+x2FIOXKAoZQ8z/y0EFMoodbcqWJY/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.9",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -10975,14 +11598,19 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.782.0",
     "@aws-sdk/client-application-auto-scaling": "^3.758.0",
+    "@aws-sdk/client-cloudfront": "^3.948.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.767.0",
     "@aws-sdk/client-ec2": "^3.767.0",
     "@aws-sdk/client-ecs": "^3.766.0",
@@ -68,6 +69,7 @@
     "husky": "^9.1.7",
     "ioredis": "^5.8.1",
     "lint-staged": "^16.1.2",
+    "mime": "^4.1.0",
     "nanospinner": "^1.2.2",
     "pathe": "^2.0.3",
     "prettier": "^3.4.2",

--- a/tests/cloudfront/certificate.test.ts
+++ b/tests/cloudfront/certificate.test.ts
@@ -1,0 +1,96 @@
+import { it } from 'node:test';
+import * as assert from 'node:assert';
+import { ListResourceRecordSetsCommand } from '@aws-sdk/client-route-53';
+import { request } from 'undici';
+import status from 'http-status';
+import { CloudFrontTestContext } from './test-context';
+import { backOff } from '../util';
+
+export function testCloudFrontWithCertificate(ctx: CloudFrontTestContext) {
+  it('should not create certificate when certificate is provided', () => {
+    const cf = ctx.outputs!.cfWithCertificate;
+
+    assert.ok(
+      cf.acmCertificate === undefined,
+      'Certificate should not be created',
+    );
+  });
+
+  it('should create alias record(s) when certificate is provided', async () => {
+    const cf = ctx.outputs!.cfWithCertificate;
+    // Ensure FQDN, i.e., end with dot if not
+    const fqdn = (name: string) => name.replace(/([^.])$/, '$1.');
+    const domainName = fqdn(ctx.config.certificateDomain);
+    const sans = ctx.config.certificateSANs.map(fqdn);
+
+    const command = new ListResourceRecordSetsCommand({
+      HostedZoneId: ctx.config.hostedZoneId,
+      MaxItems: 1000,
+    });
+    const response = await ctx.clients.route53.send(command);
+    const domainRecord = response.ResourceRecordSets?.find(
+      record => record.Name === domainName && record.Type === 'A',
+    );
+    const sanRecords = response.ResourceRecordSets?.filter(
+      record => sans.includes(record.Name!) && record.Type === 'A',
+    );
+
+    assert.ok(domainRecord, 'Alias domain record should exists');
+    assert.ok(
+      sanRecords?.length === sans.length,
+      'Alias SAN records should exists',
+    );
+
+    assert.strictEqual(
+      domainRecord.AliasTarget?.DNSName,
+      `${cf.distribution.domainName}.`,
+      'Alias domain record should target CF distribution',
+    );
+  });
+
+  it('should configure viewer certificate when certificate is provided', () => {
+    const cf = ctx.outputs!.cfWithCertificate;
+    const certificate = ctx.outputs!.certificate;
+    const { viewerCertificate } = cf.distribution;
+
+    assert.strictEqual(
+      viewerCertificate.acmCertificateArn,
+      certificate.certificate.arn,
+      'Viewer certificate should match provided certificate',
+    );
+    assert.strictEqual(
+      viewerCertificate.sslSupportMethod,
+      'sni-only',
+      'Viewer certificate should have correct SSL supported method',
+    );
+    assert.strictEqual(
+      viewerCertificate.minimumProtocolVersion,
+      'TLSv1.2_2021',
+      'Viewer certificate should have correct minimum protocol version',
+    );
+  });
+
+  it('should configure aliases when certificate is provided', () => {
+    const cf = ctx.outputs!.cfWithCertificate;
+
+    assert.deepStrictEqual(
+      cf.distribution.aliases,
+      [ctx.config.certificateDomain, ...ctx.config.certificateSANs].sort(),
+      'Aliases should be correctly configured',
+    );
+  });
+
+  it('should have reachable distribution when certificate is provided', async () => {
+    const url = `https://${ctx.config.certificateDomain}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+}

--- a/tests/cloudfront/domain.test.ts
+++ b/tests/cloudfront/domain.test.ts
@@ -1,0 +1,83 @@
+import { it } from 'node:test';
+import * as assert from 'node:assert';
+import { ListResourceRecordSetsCommand } from '@aws-sdk/client-route-53';
+import { request } from 'undici';
+import status from 'http-status';
+import { CloudFrontTestContext } from './test-context';
+import { backOff } from '../util';
+
+export function testCloudFrontWithDomain(ctx: CloudFrontTestContext) {
+  it('should create certificate when domain is provided', () => {
+    const cf = ctx.outputs!.cfWithDomain;
+
+    assert.ok(cf.acmCertificate, 'Certificate should be created');
+  });
+
+  it('should create alias record when domain is provided', async () => {
+    const cf = ctx.outputs!.cfWithDomain;
+    // Ensure FQDN, i.e., end with dot if not
+    const domainName = ctx.config.domainName.replace(/([^.])$/, '$1.');
+
+    const command = new ListResourceRecordSetsCommand({
+      HostedZoneId: ctx.config.hostedZoneId,
+      MaxItems: 1000,
+    });
+    const response = await ctx.clients.route53.send(command);
+
+    const record = response.ResourceRecordSets?.find(
+      record => record.Name === domainName && record.Type === 'A',
+    );
+
+    assert.ok(record, 'Alias record should exists');
+    assert.strictEqual(
+      record.AliasTarget?.DNSName,
+      `${cf.distribution.domainName}.`,
+      'Alias record should target CF distribution',
+    );
+  });
+
+  it('should configure viewer certificate when domain is provided', () => {
+    const cf = ctx.outputs!.cfWithDomain;
+    const { viewerCertificate } = cf.distribution;
+
+    assert.strictEqual(
+      viewerCertificate.acmCertificateArn,
+      cf.acmCertificate?.certificate.arn,
+      'Viewer certificate should match created certificate',
+    );
+    assert.strictEqual(
+      viewerCertificate.sslSupportMethod,
+      'sni-only',
+      'Viewer certificate should have correct SSL supported method',
+    );
+    assert.strictEqual(
+      viewerCertificate.minimumProtocolVersion,
+      'TLSv1.2_2021',
+      'Viewer certificate should have correct minimum protocol version',
+    );
+  });
+
+  it('should configure aliases when domain is provided', () => {
+    const cf = ctx.outputs!.cfWithDomain;
+
+    assert.deepStrictEqual(
+      cf.distribution.aliases,
+      [ctx.config.domainName],
+      'Aliases should be correctly configured',
+    );
+  });
+
+  it('should have reachable distribution when domain is provided', async () => {
+    const url = `https://${ctx.config.domainName}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+}

--- a/tests/cloudfront/index.test.ts
+++ b/tests/cloudfront/index.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, before, after } from 'node:test';
+import * as assert from 'node:assert';
+import { Unwrap } from '@pulumi/pulumi';
+import { InlineProgramArgs, OutputMap } from '@pulumi/pulumi/automation';
+import {
+  CloudFrontClient,
+  GetDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import { Route53Client } from '@aws-sdk/client-route-53';
+import { request } from 'undici';
+import status from 'http-status';
+import * as automation from '../automation';
+import { backOff, requireEnv, unwrapOutputs } from '../util';
+import { CloudFrontTestContext, ProgramOutput } from './test-context';
+import * as infraConfig from './infrastructure/config';
+import { testCloudFrontWithDomain } from './domain.test';
+import { testCloudFrontWithCertificate } from './certificate.test';
+import { testCloudFrontWithVariousBehaviors } from './various-behaviors.test';
+
+const programArgs: InlineProgramArgs = {
+  stackName: 'dev',
+  projectName: 'icb-test-cloudfront',
+  program: () => import('./infrastructure'),
+};
+
+const domainName = requireEnv('ICB_DOMAIN_NAME');
+const hostedZoneId = requireEnv('ICB_HOSTED_ZONE_ID');
+
+const ctx: CloudFrontTestContext = {
+  config: {
+    domainName,
+    hostedZoneId,
+    certificateDomain: infraConfig.certificateDomain,
+    certificateSANs: infraConfig.certificateSANs,
+    loadBalancerDomain: infraConfig.loadBalancerDomain,
+    cfMinimalName: infraConfig.cfMinimalName,
+    cfMinimalOriginId: infraConfig.cfMinimalOriginId,
+    cfMinimalOriginProtocolPolicy: infraConfig.cfMinimalOriginProtocolPolicy,
+    cfMinimalDefaultRootObject: infraConfig.cfMinimalDefaultRootObject,
+    cfWithVariousBehaviorsLbPathPattern:
+      infraConfig.cfWithVariousBehaviorsLbPathPattern,
+    cfWithVariousBehaviorsS3PathPattern:
+      infraConfig.cfWithVariousBehaviorsS3PathPattern,
+    cfWithVariousBehaviorsCustomOriginProtocolPolicy:
+      infraConfig.cfWithVariousBehaviorsCustomOriginProtocolPolicy,
+    cfWithVariousBehaviorsCustomDefaultRootObject:
+      infraConfig.cfWithVariousBehaviorsCustomDefaultRootObject,
+    cfWithVariousBehaviorsCustomAllowedMethods:
+      infraConfig.cfWithVariousBehaviorsCustomAllowedMethods,
+    cfWithVariousBehaviorsCustomCompress:
+      infraConfig.cfWithVariousBehaviorsCustomCompress,
+  },
+  clients: {
+    cf: new CloudFrontClient(),
+    route53: new Route53Client(),
+  },
+};
+
+describe('CloudFront component deployment', () => {
+  before(async () => {
+    const outputs: OutputMap = await automation.deploy(programArgs);
+
+    ctx.outputs = unwrapOutputs<ProgramOutput>(outputs);
+  });
+
+  after(() => automation.destroy(programArgs));
+
+  it('should create CloudFront component with the correct configuration', () => {
+    const cf = ctx.outputs!.cfMinimal;
+
+    assert.ok(cf, 'CloudFront component should be defined');
+    assert.strictEqual(
+      cf.name,
+      ctx.config.cfMinimalName,
+      'CloudFront component should have correct name',
+    );
+  });
+
+  it('should create distribution with the correct configuration', () => {
+    const cf = ctx.outputs!.cfMinimal;
+
+    assert.ok(cf.distribution, 'Distribution should be defined');
+    assert.strictEqual(
+      cf.distribution.origins.length,
+      1,
+      'Distribution should have one origin',
+    );
+    assert.deepStrictEqual(
+      cf.distribution.orderedCacheBehaviors,
+      [],
+      'Distribution should not have ordered cache behaviors',
+    );
+  });
+
+  it('should create distribution with correct default root object', () => {
+    const cf = ctx.outputs!.cfMinimal;
+
+    assert.strictEqual(
+      cf.distribution.defaultRootObject,
+      ctx.config.cfMinimalDefaultRootObject,
+      'Distribution should have correct default root object',
+    );
+  });
+
+  it('should create distribution with correct tags', () => {
+    const cf = ctx.outputs!.cfMinimal;
+
+    assert.deepStrictEqual(
+      cf.distribution.tags,
+      {
+        Project: 'icb-test-cloudfront',
+        Env: 'dev',
+        Application: 'cloudfront-test',
+        Name: ctx.config.cfMinimalName,
+      },
+      'Distribution should have correct tags',
+    );
+  });
+
+  it('should have deployed distribution with domain name', async () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { id } = cf.distribution;
+    const Id = id as unknown as Unwrap<typeof id>;
+
+    const command = new GetDistributionCommand({ Id });
+    const response = await ctx.clients.cf.send(command);
+    const distribution = response.Distribution;
+
+    assert.ok(distribution, 'Distribution should exist in AWS');
+    assert.ok(distribution.DomainName, 'Distribution should have domain name');
+    assert.strictEqual(
+      distribution.Status,
+      'Deployed',
+      'Distribution should have deployed status',
+    );
+  });
+
+  it('should have distribution that responds to requests', async () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const url = `https://${cf.distribution.domainName}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+
+  it('should create origin with correct ID and domain name', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const domainName = ctx.outputs!.cfMinimalOriginDomainName;
+    const { origins } = cf.distribution;
+    const [origin] = origins as unknown as Unwrap<typeof origins>;
+
+    assert.strictEqual(
+      origin.originId,
+      ctx.config.cfMinimalOriginId,
+      'Origin should have correct ID',
+    );
+    assert.strictEqual(
+      origin.domainName,
+      domainName,
+      'Origin should have correct domain name',
+    );
+  });
+
+  it('should create origin with correct protocol policy', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { origins } = cf.distribution;
+    const [origin] = origins as unknown as Unwrap<typeof origins>;
+
+    assert.strictEqual(
+      origin.customOriginConfig?.originProtocolPolicy,
+      ctx.config.cfMinimalOriginProtocolPolicy,
+      'Origin should have correct protocol policy',
+    );
+  });
+
+  it('should create origin with default HTTP(S) ports', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { origins } = cf.distribution;
+    const [origin] = origins as unknown as Unwrap<typeof origins>;
+
+    assert.strictEqual(
+      origin.customOriginConfig?.httpPort,
+      80,
+      'Should create origin with default HTTP port',
+    );
+    assert.strictEqual(
+      origin.customOriginConfig?.httpsPort,
+      443,
+      'Should create origin with default HTTPS port',
+    );
+  });
+
+  it('should create origin with default minimum SSL protocol', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { origins } = cf.distribution;
+    const [origin] = origins as unknown as Unwrap<typeof origins>;
+
+    assert.deepStrictEqual(origin.customOriginConfig?.originSslProtocols, [
+      'TLSv1.2',
+    ]);
+  });
+
+  it('should create default cache behavior with correct target origin ID', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { defaultCacheBehavior } = cf.distribution;
+
+    assert.strictEqual(
+      defaultCacheBehavior.targetOriginId,
+      ctx.config.cfMinimalOriginId,
+      'Default cache behavior should have correct target origin ID',
+    );
+  });
+
+  it('should create default cache behavior with default allowed and cached methods', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { defaultCacheBehavior } = cf.distribution;
+
+    assert.deepStrictEqual(
+      defaultCacheBehavior.allowedMethods,
+      ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
+      'Default cache behavior should have correct allowed methods',
+    );
+    assert.deepStrictEqual(
+      defaultCacheBehavior.cachedMethods,
+      ['GET', 'HEAD'],
+      'Default cache behavior should have correct cached methods',
+    );
+  });
+
+  it('should create default cache behavior with default viewer protocol policy', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { defaultCacheBehavior } = cf.distribution;
+
+    assert.strictEqual(
+      defaultCacheBehavior.viewerProtocolPolicy,
+      'redirect-to-https',
+      'Default cache behavior should have correct viewer protocol policy',
+    );
+  });
+
+  it('should create default cache behavior with default managed policies IDs', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { defaultCacheBehavior } = cf.distribution;
+
+    assert.strictEqual(
+      defaultCacheBehavior.cachePolicyId,
+      '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+      'Default cache behavior should have correct cache policy ID',
+    );
+    assert.strictEqual(
+      defaultCacheBehavior.originRequestPolicyId,
+      'b689b0a8-53d0-40ab-baf2-68738e2966ac',
+      'Default cache behavior should have correct origin request policy ID',
+    );
+    assert.strictEqual(
+      defaultCacheBehavior.responseHeadersPolicyId,
+      '67f7725c-6f97-4210-82d7-5512b31e9d03',
+      'Default cache behavior should have correct response headers policy ID',
+    );
+  });
+
+  it('should create viewer certificate with default certificate', () => {
+    const cf = ctx.outputs!.cfMinimal;
+    const { viewerCertificate } = cf.distribution;
+
+    assert.ok(
+      viewerCertificate.cloudfrontDefaultCertificate,
+      'Viewer certificate should be a default CloudFront certificate',
+    );
+  });
+
+  describe('With domain', () => testCloudFrontWithDomain(ctx));
+
+  describe('With certificate', () => testCloudFrontWithCertificate(ctx));
+
+  describe('With various behaviors', () =>
+    testCloudFrontWithVariousBehaviors(ctx));
+});

--- a/tests/cloudfront/infrastructure/assets/error.html
+++ b/tests/cloudfront/infrastructure/assets/error.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CloudFront origin website! - Error</title>
+  </head>
+
+  <body>
+    <h1>Error occurred within CloudFront origin!</h1>
+  </body>
+</html>

--- a/tests/cloudfront/infrastructure/assets/index.html
+++ b/tests/cloudfront/infrastructure/assets/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CloudFront origin website!</title>
+  </head>
+
+  <body>
+    <h1>Hello, from CloudFront origin!</h1>
+  </body>
+</html>

--- a/tests/cloudfront/infrastructure/config.ts
+++ b/tests/cloudfront/infrastructure/config.ts
@@ -1,0 +1,30 @@
+export const appName = 'cloudfront-test';
+
+export const certificateDomain = `sub.${process.env.ICB_DOMAIN_NAME}`;
+
+export const certificateSANs = [
+  `alt1.${process.env.ICB_DOMAIN_NAME}`,
+  `alt2.${process.env.ICB_DOMAIN_NAME}`,
+];
+
+export const loadBalancerDomain = `lb.${process.env.ICB_DOMAIN_NAME}`;
+
+export const cfMinimalName = `${appName}-minimal`;
+
+export const cfMinimalOriginId = `cf-minimal-oid`;
+
+export const cfMinimalOriginProtocolPolicy = 'http-only';
+
+export const cfMinimalDefaultRootObject = 'index.html';
+
+export const cfWithVariousBehaviorsLbPathPattern = '/api/*';
+
+export const cfWithVariousBehaviorsS3PathPattern = '/www/*';
+
+export const cfWithVariousBehaviorsCustomOriginProtocolPolicy = 'http-only';
+
+export const cfWithVariousBehaviorsCustomDefaultRootObject = 'index.html';
+
+export const cfWithVariousBehaviorsCustomAllowedMethods = ['GET', 'HEAD'];
+
+export const cfWithVariousBehaviorsCustomCompress = true;

--- a/tests/cloudfront/infrastructure/index.ts
+++ b/tests/cloudfront/infrastructure/index.ts
@@ -1,0 +1,203 @@
+import * as aws from '@pulumi/aws-v7';
+import * as pulumi from '@pulumi/pulumi';
+import { next as studion } from '@studion/infra-code-blocks';
+import { CloudFront } from '../../../src/v2/components/cloudfront';
+import { AcmCertificate } from '../../../src/v2/components/acm-certificate';
+import * as config from './config';
+import { OriginFactory } from './origin-factory';
+
+const domainName = process.env.ICB_DOMAIN_NAME!;
+const hostedZoneId = process.env.ICB_HOSTED_ZONE_ID;
+const tags = {
+  Project: pulumi.getProject(),
+  Environment: pulumi.getStack(),
+  Application: config.appName,
+};
+
+const parent = new pulumi.ComponentResource(
+  'studion:cf:TestGroup',
+  `${config.appName}-root`,
+);
+const vpc = new studion.Vpc(`${config.appName}-vpc`, {}, { parent });
+const hostedZone = aws.route53.getZoneOutput({
+  zoneId: hostedZoneId,
+});
+
+const originFactory = new OriginFactory({
+  namePrefix: config.appName,
+  parent,
+  tags,
+});
+
+const [, minimalWebsiteBucketConfig] =
+  originFactory.getWebsiteBucket('minimal');
+const [customWebsiteBucket, customWebsiteBucketConfig] =
+  originFactory.getWebsiteBucket('custom');
+const [s3WebsiteBucket, s3WebsiteBucketConfig] = originFactory.getWebsiteBucket(
+  's3-site',
+  'www/',
+);
+const loadBalancer = originFactory.getLoadBalancer(
+  'ws',
+  vpc.vpc,
+  config.loadBalancerDomain,
+  hostedZone.zoneId,
+);
+
+const certificate = new AcmCertificate(
+  `${config.appName}-acm-certificate`,
+  {
+    domain: config.certificateDomain,
+    subjectAlternativeNames: config.certificateSANs,
+    hostedZoneId: hostedZone.zoneId,
+    region: 'us-east-1',
+  },
+  { parent },
+);
+const customCachePolicy = new aws.cloudfront.CachePolicy(
+  `${config.appName}-custom-cp`,
+  {
+    name: `${config.appName}-custom-cache-policy`,
+    parametersInCacheKeyAndForwardedToOrigin: {
+      cookiesConfig: {
+        cookieBehavior: 'none',
+      },
+      headersConfig: {
+        headerBehavior: 'none',
+      },
+      queryStringsConfig: {
+        queryStringBehavior: 'all',
+      },
+      enableAcceptEncodingGzip: true,
+    },
+    minTtl: 1,
+    defaultTtl: 60,
+    maxTtl: 600,
+  },
+  { parent },
+);
+const customOriginRequestPolicy = new aws.cloudfront.OriginRequestPolicy(
+  `${config.appName}-custom-orp`,
+  {
+    name: `${config.appName}-custom-request-policy`,
+    cookiesConfig: {
+      cookieBehavior: 'all',
+    },
+    headersConfig: {
+      headerBehavior: 'none',
+    },
+    queryStringsConfig: {
+      queryStringBehavior: 'all',
+    },
+  },
+  { parent },
+);
+const customResponseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
+  `${config.appName}-custom-rsp`,
+  {
+    name: `${config.appName}-custom-headers-policy`,
+    customHeadersConfig: {
+      items: [
+        {
+          header: 'X-Allowed-Cross-Domains',
+          value: 'none',
+          override: true,
+        },
+      ],
+    },
+  },
+  { parent },
+);
+
+const cfMinimalOriginDomainName = minimalWebsiteBucketConfig.websiteEndpoint;
+const cfMinimalBehavior: CloudFront.Behavior = {
+  type: CloudFront.BehaviorType.CUSTOM,
+  pathPattern: '*',
+  originId: config.cfMinimalOriginId,
+  domainName: cfMinimalOriginDomainName,
+  originProtocolPolicy: config.cfMinimalOriginProtocolPolicy,
+  defaultRootObject: config.cfMinimalDefaultRootObject,
+};
+const cfMinimal = new CloudFront(
+  config.cfMinimalName,
+  {
+    behaviors: [{ ...cfMinimalBehavior }],
+    tags: {
+      Application: tags.Application,
+      Name: config.cfMinimalName,
+    },
+  },
+  { parent },
+);
+const cfWithDomain = new CloudFront(
+  `${config.appName}-domain`,
+  {
+    behaviors: [{ ...cfMinimalBehavior }],
+    domain: domainName,
+    hostedZoneId: hostedZone.zoneId,
+    tags,
+  },
+  { parent },
+);
+const cfWithCertificate = new CloudFront(
+  `${config.appName}-certificate`,
+  {
+    behaviors: [{ ...cfMinimalBehavior }],
+    certificate: certificate.certificate,
+    hostedZoneId: hostedZone.zoneId,
+    tags,
+  },
+  { parent },
+);
+const cfWithVariousBehaviors = new CloudFront(
+  `${config.appName}-various-behaviors`,
+  {
+    behaviors: [
+      {
+        type: CloudFront.BehaviorType.LB,
+        pathPattern: config.cfWithVariousBehaviorsLbPathPattern,
+        loadBalancer,
+        dnsName: config.loadBalancerDomain,
+      },
+      {
+        type: CloudFront.BehaviorType.S3,
+        pathPattern: config.cfWithVariousBehaviorsS3PathPattern,
+        bucket: s3WebsiteBucket,
+        websiteConfig: s3WebsiteBucketConfig,
+      },
+      {
+        type: CloudFront.BehaviorType.CUSTOM,
+        pathPattern: '*',
+        originId: customWebsiteBucket.id,
+        domainName: customWebsiteBucketConfig.websiteEndpoint,
+        originProtocolPolicy:
+          config.cfWithVariousBehaviorsCustomOriginProtocolPolicy,
+        defaultRootObject: config.cfWithVariousBehaviorsCustomDefaultRootObject,
+        allowedMethods: config.cfWithVariousBehaviorsCustomAllowedMethods,
+        compress: config.cfWithVariousBehaviorsCustomCompress,
+        cachePolicyId: customCachePolicy.id,
+        originRequestPolicyId: customOriginRequestPolicy.id,
+        responseHeadersPolicyId: customResponseHeadersPolicy.id,
+      },
+    ],
+    tags,
+  },
+  { parent },
+);
+
+export {
+  cfMinimalOriginDomainName,
+  cfMinimal,
+  cfWithDomain,
+  certificate,
+  cfWithCertificate,
+  loadBalancer,
+  s3WebsiteBucket,
+  s3WebsiteBucketConfig,
+  customWebsiteBucket,
+  customWebsiteBucketConfig,
+  customCachePolicy,
+  customOriginRequestPolicy,
+  customResponseHeadersPolicy,
+  cfWithVariousBehaviors,
+};

--- a/tests/cloudfront/infrastructure/origin-factory.ts
+++ b/tests/cloudfront/infrastructure/origin-factory.ts
@@ -1,0 +1,163 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as aws from '@pulumi/aws-v7';
+import * as awsx from '@pulumi/awsx-v3';
+import * as pulumi from '@pulumi/pulumi';
+import mime from 'mime';
+import { next as studion } from '@studion/infra-code-blocks';
+
+export namespace OriginFactory {
+  export type Args = {
+    namePrefix: string;
+    parent: pulumi.ComponentResource;
+    tags: {
+      [key: string]: string;
+    };
+  };
+}
+
+export class OriginFactory {
+  private readonly stackName;
+  private readonly namePrefix;
+  private readonly parent;
+  private readonly tags;
+
+  constructor(args: OriginFactory.Args) {
+    this.stackName = pulumi.getStack();
+    this.namePrefix = args.namePrefix;
+    this.parent = args.parent;
+    this.tags = args.tags;
+  }
+
+  getWebsiteBucket(
+    id: string,
+    prefix?: string,
+  ): [aws.s3.Bucket, aws.s3.BucketWebsiteConfiguration] {
+    const name = `${this.namePrefix}-${id}-bucket`;
+    const bucket = new aws.s3.Bucket(
+      name,
+      { tags: this.tags },
+      { parent: this.parent },
+    );
+    const config = new aws.s3.BucketWebsiteConfiguration(
+      `${name}-website-config`,
+      {
+        bucket: bucket.id,
+        indexDocument: {
+          suffix: 'index.html',
+        },
+        errorDocument: {
+          key: 'error.html',
+        },
+      },
+      { parent: this.parent },
+    );
+
+    const bucketPublicAccessBlock = new aws.s3.BucketPublicAccessBlock(
+      `${name}-access-block`,
+      {
+        bucket: bucket.id,
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false,
+      },
+      { parent: this.parent },
+    );
+
+    const policy = bucket.bucket.apply(bucketName =>
+      aws.iam.getPolicyDocument({
+        statements: [
+          {
+            effect: 'Allow',
+            principals: [
+              {
+                type: '*',
+                identifiers: ['*'],
+              },
+            ],
+            actions: ['s3:GetObject'],
+            resources: [`arn:aws:s3:::${bucketName}/*`],
+          },
+        ],
+      }),
+    );
+
+    new aws.s3.BucketPolicy(
+      `${name}-policy`,
+      {
+        bucket: bucket.id,
+        policy: policy.json,
+      },
+      { parent: this.parent, dependsOn: [bucketPublicAccessBlock] },
+    );
+
+    this.uploadAssets(name, bucket, prefix);
+
+    return [bucket, config];
+  }
+
+  getLoadBalancer(
+    id: string,
+    vpc: pulumi.Input<awsx.ec2.Vpc>,
+    domainName: string,
+    hostedZoneId: pulumi.Input<string>,
+  ): aws.lb.LoadBalancer {
+    const name = `${this.namePrefix}-${id}`;
+    const cluster = new aws.ecs.Cluster(
+      `${name}-cluster`,
+      {
+        name: `${this.namePrefix}-cluster-${this.stackName}`,
+        tags: this.tags,
+      },
+      { parent: this.parent },
+    );
+
+    const webServer = new studion.WebServerBuilder(name)
+      .configureWebServer('nginxdemos/nginx-hello:plain-text', 8080)
+      .configureEcs({
+        cluster,
+        desiredCount: 1,
+        size: 'small',
+        autoscaling: { enabled: false },
+        tags: this.tags,
+      })
+      .withCustomDomain(domainName, hostedZoneId)
+      .withVpc(vpc)
+      .build({ parent: cluster });
+
+    return webServer.lb.lb;
+  }
+
+  private uploadAssets(
+    name: string,
+    bucket: aws.s3.Bucket,
+    prefix: string = '',
+  ) {
+    const dir = path.join(
+      process.cwd(),
+      './tests/cloudfront/infrastructure/assets',
+    );
+    const files = fs.readdirSync(dir);
+
+    for (const file of files) {
+      const filePath = `${dir}/${file}`;
+      const stat = fs.statSync(filePath);
+
+      if (stat.isDirectory()) {
+        continue;
+      }
+
+      new aws.s3.BucketObject(
+        `${name}-${file}`,
+        {
+          key: `${prefix}${file}`,
+          bucket: bucket.id,
+          contentType: mime.getType(file) || undefined,
+          source: new pulumi.asset.FileAsset(filePath),
+        },
+        { parent: bucket },
+      );
+    }
+  }
+}

--- a/tests/cloudfront/test-context.ts
+++ b/tests/cloudfront/test-context.ts
@@ -1,0 +1,51 @@
+import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
+import { Route53Client } from '@aws-sdk/client-route-53';
+import * as aws from '@pulumi/aws-v7';
+import { CloudFront } from '../../src/v2/components/cloudfront';
+import { AcmCertificate } from '../../src/v2/components/acm-certificate';
+import { AwsContext, ConfigContext, PulumiProgramContext } from '../types';
+
+interface Config {
+  domainName: string;
+  hostedZoneId: string;
+  certificateDomain: string;
+  certificateSANs: string[];
+  loadBalancerDomain: string;
+  cfMinimalName: string;
+  cfMinimalOriginId: string;
+  cfMinimalOriginProtocolPolicy: string;
+  cfMinimalDefaultRootObject: string;
+  cfWithVariousBehaviorsLbPathPattern: string;
+  cfWithVariousBehaviorsS3PathPattern: string;
+  cfWithVariousBehaviorsCustomOriginProtocolPolicy: string;
+  cfWithVariousBehaviorsCustomDefaultRootObject: string;
+  cfWithVariousBehaviorsCustomAllowedMethods: string[];
+  cfWithVariousBehaviorsCustomCompress: boolean;
+}
+
+interface AwsClients {
+  cf: CloudFrontClient;
+  route53: Route53Client;
+}
+
+export interface ProgramOutput {
+  cfMinimalOriginDomainName: string;
+  cfMinimal: CloudFront;
+  cfWithDomain: CloudFront;
+  certificate: AcmCertificate;
+  cfWithCertificate: CloudFront;
+  loadBalancer: aws.lb.LoadBalancer;
+  s3WebsiteBucket: aws.s3.Bucket;
+  s3WebsiteBucketConfig: aws.s3.BucketWebsiteConfiguration;
+  customWebsiteBucket: aws.s3.Bucket;
+  customWebsiteBucketConfig: aws.s3.BucketWebsiteConfiguration;
+  customCachePolicy: aws.cloudfront.CachePolicy;
+  customOriginRequestPolicy: aws.cloudfront.OriginRequestPolicy;
+  customResponseHeadersPolicy: aws.cloudfront.ResponseHeadersPolicy;
+  cfWithVariousBehaviors: CloudFront;
+}
+
+export interface CloudFrontTestContext
+  extends ConfigContext<Config>,
+    AwsContext<AwsClients>,
+    PulumiProgramContext<ProgramOutput> {}

--- a/tests/cloudfront/various-behaviors.test.ts
+++ b/tests/cloudfront/various-behaviors.test.ts
@@ -1,0 +1,414 @@
+import { it } from 'node:test';
+import * as assert from 'node:assert';
+import { Unwrap } from '@pulumi/pulumi';
+import { request } from 'undici';
+import status from 'http-status';
+import { CloudFrontTestContext } from './test-context';
+import { backOff } from '../util';
+import {
+  GetCachePolicyCommand,
+  GetResponseHeadersPolicyCommand,
+} from '@aws-sdk/client-cloudfront';
+
+export function testCloudFrontWithVariousBehaviors(ctx: CloudFrontTestContext) {
+  it('should have origins correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const origins = dist.origins as unknown as Unwrap<typeof dist.origins>;
+
+    assert.strictEqual(origins.length, 3, 'Origins should have length of 3');
+  });
+
+  it('should have origin for LB behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const lb = ctx.outputs!.loadBalancer;
+    const lbArn = lb.arn as unknown as Unwrap<typeof lb.arn>;
+    const dist = cf.distribution;
+    const origins = dist.origins as unknown as Unwrap<typeof dist.origins>;
+    const lbOrigin = origins.find(it => it.originId === lbArn);
+
+    assert.partialDeepStrictEqual(
+      lbOrigin,
+      {
+        domainName: ctx.config.loadBalancerDomain,
+        customOriginConfig: {
+          originProtocolPolicy: 'https-only',
+        },
+      },
+      'Load balancer origin should exist and be correctly configured',
+    );
+  });
+
+  it('should have origin for S3 behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const s3Bucket = ctx.outputs!.s3WebsiteBucket;
+    const s3WsConfig = ctx.outputs!.s3WebsiteBucketConfig;
+    const bucketArn = s3Bucket.arn as unknown as Unwrap<typeof s3Bucket.arn>;
+    const dist = cf.distribution;
+    const origins = dist.origins as unknown as Unwrap<typeof dist.origins>;
+    const s3Origin = origins.find(it => it.originId === bucketArn);
+
+    assert.partialDeepStrictEqual(
+      s3Origin,
+      {
+        domainName: s3WsConfig.websiteEndpoint,
+        customOriginConfig: {
+          originProtocolPolicy: 'http-only',
+        },
+      },
+      'S3 origin should exist and be correctly configured',
+    );
+  });
+
+  it('should have origin for Custom behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const customBucket = ctx.outputs!.customWebsiteBucket;
+    const customWsConfig = ctx.outputs!.customWebsiteBucketConfig;
+    const bucketId = customBucket.id as unknown as Unwrap<
+      typeof customBucket.id
+    >;
+    const dist = cf.distribution;
+    const origins = dist.origins as unknown as Unwrap<typeof dist.origins>;
+    const customOrigin = origins.find(it => it.originId === bucketId);
+
+    assert.partialDeepStrictEqual(
+      customOrigin,
+      {
+        domainName: customWsConfig.websiteEndpoint,
+        customOriginConfig: {
+          originProtocolPolicy:
+            ctx.config.cfWithVariousBehaviorsCustomOriginProtocolPolicy,
+        },
+      },
+      'Custom origin should exist and be correctly configured',
+    );
+  });
+
+  it('should have default cache behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const customBucket = ctx.outputs!.customWebsiteBucket;
+    const cachePolicy = ctx.outputs!.customCachePolicy;
+    const originRequestPolicy = ctx.outputs!.customOriginRequestPolicy;
+    const responseHeadersPolicy = ctx.outputs!.customResponseHeadersPolicy;
+    const dist = cf.distribution;
+
+    assert.partialDeepStrictEqual(
+      dist.defaultCacheBehavior,
+      {
+        targetOriginId: customBucket.id,
+        allowedMethods: ctx.config.cfWithVariousBehaviorsCustomAllowedMethods,
+        compress: ctx.config.cfWithVariousBehaviorsCustomCompress,
+        viewerProtocolPolicy: 'redirect-to-https',
+        cachePolicyId: cachePolicy.id,
+        originRequestPolicyId: originRequestPolicy.id,
+        responseHeadersPolicyId: responseHeadersPolicy.id,
+      },
+      'Default cache behavior should be correctly configured',
+    );
+  });
+
+  it('should have ordered cache behaviors correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+
+    assert.strictEqual(
+      orderedCacheBehaviors?.length,
+      2,
+      'Ordered cache behaviors should have length of 2',
+    );
+  });
+
+  it('should have ordered cache behavior for LB behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const lb = ctx.outputs!.loadBalancer;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const lbCache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsLbPathPattern,
+    );
+
+    assert.partialDeepStrictEqual(
+      lbCache,
+      {
+        targetOriginId: lb.arn,
+        allowedMethods: [
+          'DELETE',
+          'GET',
+          'HEAD',
+          'OPTIONS',
+          'PATCH',
+          'POST',
+          'PUT',
+        ],
+        cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
+        compress: true,
+        viewerProtocolPolicy: 'redirect-to-https',
+        originRequestPolicyId: '216adef6-5c7f-47e4-b989-5492eafa07d3',
+      },
+      'Load balancer ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have cache policy of LB ordered cache behavior correctly configured', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const lbCache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsLbPathPattern,
+    );
+
+    const command = new GetCachePolicyCommand({ Id: lbCache!.cachePolicyId });
+    const response = await ctx.clients.cf.send(command);
+    const cachePolicy = response.CachePolicy;
+
+    assert.partialDeepStrictEqual(
+      cachePolicy?.CachePolicyConfig,
+      {
+        DefaultTTL: 0,
+        MinTTL: 0,
+        MaxTTL: 3600, // 1 hour
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          CookiesConfig: {
+            CookieBehavior: 'none',
+          },
+          HeadersConfig: {
+            HeaderBehavior: 'none',
+          },
+          QueryStringsConfig: {
+            QueryStringBehavior: 'all',
+          },
+          EnableAcceptEncodingGzip: true,
+          EnableAcceptEncodingBrotli: true,
+        },
+      },
+      'Cache policy of LB ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have response headers policy of LB ordered cache behavior correctly configured', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const lbCache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsLbPathPattern,
+    );
+
+    const command = new GetResponseHeadersPolicyCommand({
+      Id: lbCache!.responseHeadersPolicyId,
+    });
+    const response = await ctx.clients.cf.send(command);
+    const responseHeadersPolicy = response.ResponseHeadersPolicy;
+
+    assert.partialDeepStrictEqual(
+      responseHeadersPolicy?.ResponseHeadersPolicyConfig,
+      {
+        CustomHeadersConfig: {
+          Items: [
+            {
+              Header: 'Cache-Control',
+              Value: 'no-store',
+              Override: false,
+            },
+          ],
+        },
+        SecurityHeadersConfig: {
+          ContentTypeOptions: {
+            Override: true,
+          },
+          FrameOptions: {
+            FrameOption: 'SAMEORIGIN',
+            Override: false,
+          },
+          ReferrerPolicy: {
+            ReferrerPolicy: 'strict-origin-when-cross-origin',
+            Override: false,
+          },
+          StrictTransportSecurity: {
+            AccessControlMaxAgeSec: 31536000,
+            IncludeSubdomains: true,
+            Preload: true,
+            Override: true,
+          },
+        },
+      },
+      'Response headers policy of LB ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have ordered cache behavior for S3 behavior correctly configured', () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const s3Bucket = ctx.outputs!.s3WebsiteBucket;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const s3Cache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsS3PathPattern,
+    );
+
+    assert.partialDeepStrictEqual(
+      s3Cache,
+      {
+        targetOriginId: s3Bucket.arn,
+        allowedMethods: ['GET', 'HEAD'],
+        cachedMethods: ['GET', 'HEAD'],
+        compress: true,
+        viewerProtocolPolicy: 'redirect-to-https',
+        originRequestPolicyId: '',
+      },
+      'S3 ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have cache policy of S3 ordered cache behavior correctly configured', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const s3Cache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsS3PathPattern,
+    );
+
+    const command = new GetCachePolicyCommand({ Id: s3Cache!.cachePolicyId });
+    const response = await ctx.clients.cf.send(command);
+    const cachePolicy = response.CachePolicy;
+
+    assert.partialDeepStrictEqual(
+      cachePolicy?.CachePolicyConfig,
+      {
+        DefaultTTL: 86400,
+        MinTTL: 60,
+        MaxTTL: 31536000,
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          CookiesConfig: {
+            CookieBehavior: 'none',
+          },
+          HeadersConfig: {
+            HeaderBehavior: 'none',
+          },
+          QueryStringsConfig: {
+            QueryStringBehavior: 'none',
+          },
+          EnableAcceptEncodingGzip: true,
+          EnableAcceptEncodingBrotli: true,
+        },
+      },
+      'Cache policy of S3 ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have response headers policy of S3 ordered cache behavior correctly configured', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const orderedCacheBehaviors =
+      dist.orderedCacheBehaviors as unknown as Unwrap<
+        typeof dist.orderedCacheBehaviors
+      >;
+    const s3Cache = orderedCacheBehaviors?.find(
+      it => it.pathPattern === ctx.config.cfWithVariousBehaviorsS3PathPattern,
+    );
+
+    const command = new GetResponseHeadersPolicyCommand({
+      Id: s3Cache!.responseHeadersPolicyId,
+    });
+    const response = await ctx.clients.cf.send(command);
+    const responseHeadersPolicy = response.ResponseHeadersPolicy;
+
+    assert.partialDeepStrictEqual(
+      responseHeadersPolicy?.ResponseHeadersPolicyConfig,
+      {
+        CustomHeadersConfig: {
+          Items: [
+            {
+              Header: 'Cache-Control',
+              Value: 'no-cache',
+              Override: false,
+            },
+          ],
+        },
+        SecurityHeadersConfig: {
+          ContentTypeOptions: {
+            Override: true,
+          },
+          FrameOptions: {
+            FrameOption: 'DENY',
+            Override: true,
+          },
+          StrictTransportSecurity: {
+            AccessControlMaxAgeSec: 31536000,
+            IncludeSubdomains: true,
+            Preload: true,
+            Override: true,
+          },
+        },
+      },
+      'Response headers policy of S3 ordered cache behavior must be correctly configured',
+    );
+  });
+
+  it('should have distribution that respond to requests for LB Origin', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const path = ctx.config.cfWithVariousBehaviorsLbPathPattern.slice(0, -1);
+    const url = `https://${dist.domainName}${path}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution for LB origin should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+
+  it('should have distribution that respond to requests for S3 Origin', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const path = ctx.config.cfWithVariousBehaviorsS3PathPattern.slice(0, -1);
+    const url = `https://${dist.domainName}${path}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution for S3 origin should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+
+  it('should have distribution that respond to requests for Custom Origin', async () => {
+    const cf = ctx.outputs!.cfWithVariousBehaviors;
+    const dist = cf.distribution;
+    const url = `https://${dist.domainName}`;
+
+    await backOff(async () => {
+      const response = await request(url);
+
+      assert.strictEqual(
+        response.statusCode,
+        status.OK,
+        `Distribution for Custom origin should respond with status code 200, got ${response.statusCode}`,
+      );
+    });
+  });
+}

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,11 @@
+export interface ConfigContext<T extends Record<string, any>> {
+  config: T;
+}
+
+export interface AwsContext<U extends Record<string, any>> {
+  clients: U;
+}
+
+export interface PulumiProgramContext<S extends Record<string, any>> {
+  outputs?: S;
+}

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,3 +1,14 @@
+import { OutputMap } from '@pulumi/pulumi/automation';
+import { backOff as backOffFn, BackoffOptions } from 'exponential-backoff';
+
+const backOffDefaults: BackoffOptions = {
+  delayFirstAttempt: true,
+  numOfAttempts: 5,
+  startingDelay: 1500,
+  timeMultiple: 2,
+  jitter: 'full',
+};
+
 export function requireEnv(name: string): string {
   const value = process.env[name];
 
@@ -6,4 +17,23 @@ export function requireEnv(name: string): string {
   }
 
   return value;
+}
+
+export function backOff<T>(request: () => Promise<T>): Promise<T> {
+  return backOffFn(request, backOffDefaults);
+}
+
+export function unwrapOutputs<T extends Record<string, any>>(
+  outputMap: OutputMap,
+): T {
+  const unwrapped = {} as T;
+
+  for (const [key, outputValue] of Object.entries(outputMap) as [
+    keyof T,
+    T[keyof T],
+  ][]) {
+    unwrapped[key] = outputValue.value;
+  }
+
+  return unwrapped;
 }


### PR DESCRIPTION
Integration test for CloudFront component. Tests cover cases around various origins, and domain/certificate creation.
Adds `@aws-sdk/client-cloudfront` and `mime` as dev dependencies.