### PR TITLE
ci: return exit code from `test` script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,14 @@ jobs:
           role_arn: ${AWS_ROLE_ARN}
       - setup-pulumi
       - node/install
-      - core/run_script:
-          script: 'test'
+      - core/install_dependencies
+      - run:
+          name: Run component tests
+          command: |
+            npm run test
+            CODE=$?
+            echo $CODE
+            exit $CODE
 
 workflows:
   scan-and-test:
@@ -78,4 +84,4 @@ workflows:
       - test-build:
           filters: *change-filters
       - test-components:
-          filters: *trunk-filters
+          filters: *change-filters


### PR DESCRIPTION
Capture exit code from `test` script and exit with it. Without this step, when test are failing, success status code is returned. Exact reason for this behavior in the current moment is unknown and will not be pursued for now.