### PR TITLE
fix: move test setup to the top-level to prevent false positives

### DIFF
--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,9 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required.`);
+  }
+
+  return value;
+}

--- a/tests/vpc/index.test.ts
+++ b/tests/vpc/index.test.ts
@@ -14,6 +14,7 @@ import {
   VpcState,
 } from '@aws-sdk/client-ec2';
 import { defaults as vpcDefaults } from '../../src/v2/components/vpc';
+import { requireEnv } from '../util';
 
 const programArgs: InlineProgramArgs = {
   stackName: 'dev',
@@ -21,20 +22,16 @@ const programArgs: InlineProgramArgs = {
   program: () => import('./infrastructure'),
 };
 
+const region = requireEnv('AWS_REGION');
+const ctx: VpcTestContext = {
+  outputs: {},
+  config: {},
+  clients: {
+    ec2: new EC2Client({ region }),
+  },
+};
+
 describe('Vpc component deployment', () => {
-  const region = process.env.AWS_REGION;
-  if (!region) {
-    throw new Error('AWS_REGION environment variable is required');
-  }
-
-  const ctx: VpcTestContext = {
-    outputs: {},
-    config: {},
-    clients: {
-      ec2: new EC2Client({ region }),
-    },
-  };
-
   before(async () => {
     ctx.outputs = await automation.deploy(programArgs);
   });


### PR DESCRIPTION
Test setup logic, environment variable checks and test context building, inside describe blocks caused silent failures.
When setup logic threw errors, zero tests executed, producing a falsy exit code 0 that CI treated as success.

Moving setup logic to the top-level ensures proper error propagation, returning exit code 1 on setup failure and correctly failing the build.