### PR TITLE
fix: increase AWS token session duration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
       - checkout
       - aws-cli/setup:
           role_arn: ${AWS_ROLE_ARN}
+          session_duration: '7200'
       - setup-pulumi
       - node/install
       - core/run_script:


### PR DESCRIPTION
Current default session duration was 1 hour, since tests run longer than that, we need to increase this to 2hours