### PR TITLE
task: update load balancer listener ssl policy

### DIFF
--- a/src/v2/components/web-server/load-balancer.ts
+++ b/src/v2/components/web-server/load-balancer.ts
@@ -111,7 +111,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
         loadBalancerArn: lb.arn,
         port: 443,
         protocol: 'HTTPS',
-        sslPolicy: 'ELBSecurityPolicy-2016-08',
+        sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06',
         certificateArn: certificate.arn,
         defaultActions: [
           {


### PR DESCRIPTION
Update load balancer SSL policy to `ELBSecurityPolicy-TLS13-1-2-2021-06` (enforces TLS 1.2+/TLS 1.3, modern ciphers, improved security and performance).