### PR TITLE
fix: update glob pattern to include all test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "npm run clean && tsc -b src",
     "format": "prettier -w .",
     "release": "release-it --only-version",
-    "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=1 -r ts-node/register tests/**[!build]/index.test.ts",
+    "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=1 -r ts-node/register tests/**/index.test.ts",
     "test:build": "npm run build && tstyche build",
     "prepare": "husky"
   },


### PR DESCRIPTION
Glob pattern for test file matching, contained negated character class which matches single character not the whole word. This resulted in skipping `password` and `otel` tests since their path contained negated characters.
Removing negated character class resolves the issue. Since the build tests use `tst.ts` extension they will not be matched by the glob pattern.