### PR TITLE
chore: bump test concurrency to `2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "npm run clean && tsc -b src",
     "format": "prettier -w .",
     "release": "release-it --only-version",
-    "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=1 -r ts-node/register tests/**/index.test.ts",
+    "test": "TS_NODE_PROJECT=tests node --test --test-concurrency=2 -r ts-node/register tests/**/index.test.ts",
     "test:build": "npm run build && tstyche build",
     "prepare": "husky"
   },

--- a/tests/automation.ts
+++ b/tests/automation.ts
@@ -5,11 +5,17 @@ import {
   OutputMap,
 } from '@pulumi/pulumi/automation';
 import { createSpinner } from 'nanospinner';
+import { requireEnv } from './util';
 
-export async function deploy(args: InlineProgramArgs): Promise<OutputMap> {
+export async function deploy(
+  args: InlineProgramArgs,
+  region?: string,
+): Promise<OutputMap> {
   const spinner = createSpinner('Deploying stack...').start();
   const stack = await LocalWorkspace.createOrSelectStack(args);
-  await stack.setConfig('aws:region', { value: 'us-east-2' });
+  await stack.setConfig('aws:region', {
+    value: region ?? requireEnv('AWS_REGION'),
+  });
   const up = await stack.up({ logToStdErr: true });
   spinner.success({ text: 'Stack deployed' });
 

--- a/tests/vpc/index.test.ts
+++ b/tests/vpc/index.test.ts
@@ -14,7 +14,6 @@ import {
   VpcState,
 } from '@aws-sdk/client-ec2';
 import { defaults as vpcDefaults } from '../../src/v2/components/vpc';
-import { requireEnv } from '../util';
 
 const programArgs: InlineProgramArgs = {
   stackName: 'dev',
@@ -22,7 +21,8 @@ const programArgs: InlineProgramArgs = {
   program: () => import('./infrastructure'),
 };
 
-const region = requireEnv('AWS_REGION');
+const region =
+  process.env.AWS_REGION === 'eu-west-1' ? 'eu-north-1' : 'eu-west-1';
 const ctx: VpcTestContext = {
   outputs: {},
   config: {},
@@ -33,7 +33,7 @@ const ctx: VpcTestContext = {
 
 describe('Vpc component deployment', () => {
   before(async () => {
-    ctx.outputs = await automation.deploy(programArgs);
+    ctx.outputs = await automation.deploy(programArgs, region);
   });
 
   after(() => automation.destroy(programArgs));


### PR DESCRIPTION
Increase test concurrency to 2 to speed up test execution, around 25% improvement.
For this to work `vpc` test are executed in region other than one specified by `AWS_REGION`, so EIP limit is not hit since it is per region.