### PR TITLE
test: make upstash redis env variables required

### DIFF
--- a/tests/redis/index.test.ts
+++ b/tests/redis/index.test.ts
@@ -18,8 +18,8 @@ const programArgs: InlineProgramArgs = {
 };
 
 const region = requireEnv('AWS_REGION');
-const hasUpstashCredentials =
-  process.env.UPSTASH_EMAIL && process.env.UPSTASH_API_KEY;
+requireEnv('UPSTASH_EMAIL');
+requireEnv('UPSTASH_API_KEY');
 const ctx: RedisTestContext = {
   outputs: {},
   config: {
@@ -52,11 +52,5 @@ describe('Redis component deployment', () => {
   after(() => automation.destroy(programArgs));
 
   describe('ElastiCache Redis', () => testElastiCacheRedis(ctx));
-  if (hasUpstashCredentials) {
-    describe('Upstash Redis', () => testUpstashRedis(ctx));
-  } else {
-    console.log(
-      'Skipping Upstash redis tests, Upstash credentials were not provided...',
-    );
-  }
+  describe('Upstash Redis', () => testUpstashRedis(ctx));
 });

--- a/tests/redis/infrastructure/index.ts
+++ b/tests/redis/infrastructure/index.ts
@@ -113,23 +113,18 @@ const testClient = new studion.EcsService(
   { parent },
 );
 
-let upstashRedis: studion.UpstashRedis | undefined;
-const upstashEmail = process.env.UPSTASH_EMAIL;
-const upstashApiKey = process.env.UPSTASH_API_KEY;
-if (upstashEmail && upstashApiKey) {
-  const upstashProvider = new upstash.Provider('upstash', {
-    email: upstashEmail,
-    apiKey: upstashApiKey,
-  });
+const upstashProvider = new upstash.Provider('upstash', {
+  email: process.env.UPSTASH_EMAIL,
+  apiKey: process.env.UPSTASH_API_KEY,
+});
 
-  upstashRedis = new studion.UpstashRedis(
-    `${appName}-upstash`,
-    {
-      dbName: `${appName}-upstash`,
-    },
-    { provider: upstashProvider, parent },
-  );
-}
+const upstashRedis = new studion.UpstashRedis(
+  `${appName}-upstash`,
+  {
+    dbName: `${appName}-upstash`,
+  },
+  { provider: upstashProvider, parent },
+);
 
 module.exports = {
   vpc,
@@ -137,5 +132,5 @@ module.exports = {
   elastiCacheRedis,
   cluster,
   testClient,
-  ...(upstashRedis && { upstashRedis }),
+  upstashRedis,
 };


### PR DESCRIPTION
This PR makes upstash redis environment variables required so tests can't be skipped anymore. 