### PR TITLE
build: update `tar` for `@pulumi/pulumi` to `7.5.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12647,9 +12647,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.3.tgz",
-      "integrity": "sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "overrides": {
     "@pulumi/pulumi": {
       "glob": "10.5.0",
-      "tar": "7.5.3"
+      "tar": "7.5.6"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
To resolve high severity vulnerability update overridden version of `tar` for `@pulumi/pulumi`.