### PR TITLE
refactor: export CloudFront component

### DIFF
--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -9,6 +9,7 @@ export { Database } from './components/database';
 export { DatabaseBuilder } from './components/database/builder';
 export { AcmCertificate } from './components/acm-certificate';
 export { Password } from './components/password';
+export { CloudFront } from './components/cloudfront';
 
 import { OtelCollectorBuilder } from './otel/builder';
 import { OtelCollector } from './otel';

--- a/tests/build/index.tst.ts
+++ b/tests/build/index.tst.ts
@@ -342,4 +342,46 @@ describe('Build output', () => {
       });
     });
   });
+
+  describe('CloudFront', () => {
+    it('should export CloudFront', () => {
+      expect(studion).type.toHaveProperty('CloudFront');
+    });
+
+    describe('Instantiation', () => {
+      const { CloudFront } = studion;
+
+      it('should construct CloudFront', () => {
+        expect(CloudFront).type.toBeConstructableWith('cfName', {
+          behaviors: [],
+        });
+      });
+    });
+
+    describe('BehaviorType', () => {
+      const { CloudFront } = studion;
+
+      it('should export BehaviorType', () => {
+        expect(CloudFront).type.toHaveProperty('BehaviorType');
+      });
+
+      describe('Members', () => {
+        const {
+          CloudFront: { BehaviorType },
+        } = studion;
+
+        it('should export CUSTOM', () => {
+          expect(BehaviorType).type.toHaveProperty('CUSTOM');
+        });
+
+        it('should export LB', () => {
+          expect(BehaviorType).type.toHaveProperty('LB');
+        });
+
+        it('should export S3', () => {
+          expect(BehaviorType).type.toHaveProperty('S3');
+        });
+      });
+    });
+  });
 });

--- a/tests/cloudfront/infrastructure/index.ts
+++ b/tests/cloudfront/infrastructure/index.ts
@@ -1,8 +1,6 @@
 import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
 import { next as studion } from '@studion/infra-code-blocks';
-import { CloudFront } from '../../../src/v2/components/cloudfront';
-import { AcmCertificate } from '../../../src/v2/components/acm-certificate';
 import * as config from './config';
 import { OriginFactory } from './origin-factory';
 
@@ -43,7 +41,7 @@ const loadBalancer = originFactory.getLoadBalancer(
   hostedZone.zoneId,
 );
 
-const certificate = new AcmCertificate(
+const certificate = new studion.AcmCertificate(
   `${config.appName}-acm-certificate`,
   {
     domain: config.certificateDomain,
@@ -109,15 +107,15 @@ const customResponseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
 );
 
 const cfMinimalOriginDomainName = minimalWebsiteBucketConfig.websiteEndpoint;
-const cfMinimalBehavior: CloudFront.Behavior = {
-  type: CloudFront.BehaviorType.CUSTOM,
+const cfMinimalBehavior: studion.CloudFront.Behavior = {
+  type: studion.CloudFront.BehaviorType.CUSTOM,
   pathPattern: '*',
   originId: config.cfMinimalOriginId,
   domainName: cfMinimalOriginDomainName,
   originProtocolPolicy: config.cfMinimalOriginProtocolPolicy,
   defaultRootObject: config.cfMinimalDefaultRootObject,
 };
-const cfMinimal = new CloudFront(
+const cfMinimal = new studion.CloudFront(
   config.cfMinimalName,
   {
     behaviors: [{ ...cfMinimalBehavior }],
@@ -128,7 +126,7 @@ const cfMinimal = new CloudFront(
   },
   { parent },
 );
-const cfWithDomain = new CloudFront(
+const cfWithDomain = new studion.CloudFront(
   `${config.appName}-domain`,
   {
     behaviors: [{ ...cfMinimalBehavior }],
@@ -138,7 +136,7 @@ const cfWithDomain = new CloudFront(
   },
   { parent },
 );
-const cfWithCertificate = new CloudFront(
+const cfWithCertificate = new studion.CloudFront(
   `${config.appName}-certificate`,
   {
     behaviors: [{ ...cfMinimalBehavior }],
@@ -148,24 +146,24 @@ const cfWithCertificate = new CloudFront(
   },
   { parent },
 );
-const cfWithVariousBehaviors = new CloudFront(
+const cfWithVariousBehaviors = new studion.CloudFront(
   `${config.appName}-various-behaviors`,
   {
     behaviors: [
       {
-        type: CloudFront.BehaviorType.LB,
+        type: studion.CloudFront.BehaviorType.LB,
         pathPattern: config.cfWithVariousBehaviorsLbPathPattern,
         loadBalancer,
         dnsName: config.loadBalancerDomain,
       },
       {
-        type: CloudFront.BehaviorType.S3,
+        type: studion.CloudFront.BehaviorType.S3,
         pathPattern: config.cfWithVariousBehaviorsS3PathPattern,
         bucket: s3WebsiteBucket,
         websiteConfig: s3WebsiteBucketConfig,
       },
       {
-        type: CloudFront.BehaviorType.CUSTOM,
+        type: studion.CloudFront.BehaviorType.CUSTOM,
         pathPattern: '*',
         originId: customWebsiteBucket.id,
         domainName: customWebsiteBucketConfig.websiteEndpoint,

--- a/tests/cloudfront/test-context.ts
+++ b/tests/cloudfront/test-context.ts
@@ -1,8 +1,7 @@
 import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
 import { Route53Client } from '@aws-sdk/client-route-53';
 import * as aws from '@pulumi/aws-v7';
-import { CloudFront } from '../../src/v2/components/cloudfront';
-import { AcmCertificate } from '../../src/v2/components/acm-certificate';
+import { next as studion } from '@studion/infra-code-blocks';
 import { AwsContext, ConfigContext, PulumiProgramContext } from '../types';
 
 interface Config {
@@ -30,10 +29,10 @@ interface AwsClients {
 
 export interface ProgramOutput {
   cfMinimalOriginDomainName: string;
-  cfMinimal: CloudFront;
-  cfWithDomain: CloudFront;
-  certificate: AcmCertificate;
-  cfWithCertificate: CloudFront;
+  cfMinimal: studion.CloudFront;
+  cfWithDomain: studion.CloudFront;
+  certificate: studion.AcmCertificate;
+  cfWithCertificate: studion.CloudFront;
   loadBalancer: aws.lb.LoadBalancer;
   s3WebsiteBucket: aws.s3.Bucket;
   s3WebsiteBucketConfig: aws.s3.BucketWebsiteConfiguration;
@@ -42,7 +41,7 @@ export interface ProgramOutput {
   customCachePolicy: aws.cloudfront.CachePolicy;
   customOriginRequestPolicy: aws.cloudfront.OriginRequestPolicy;
   customResponseHeadersPolicy: aws.cloudfront.ResponseHeadersPolicy;
-  cfWithVariousBehaviors: CloudFront;
+  cfWithVariousBehaviors: studion.CloudFront;
 }
 
 export interface CloudFrontTestContext


### PR DESCRIPTION
The CloudFront component is now available for use in v2. 
Add build tests for the CloudFront component.

Depends on: #101 