### PR TITLE
fix: prefix domains in CloudFront tests

### DIFF
--- a/tests/cloudfront/domain.test.ts
+++ b/tests/cloudfront/domain.test.ts
@@ -16,7 +16,7 @@ export function testCloudFrontWithDomain(ctx: CloudFrontTestContext) {
   it('should create alias record when domain is provided', async () => {
     const cf = ctx.outputs!.cfWithDomain;
     // Ensure FQDN, i.e., end with dot if not
-    const domainName = ctx.config.domainName.replace(/([^.])$/, '$1.');
+    const domainName = ctx.config.defaultDomain.replace(/([^.])$/, '$1.');
 
     const command = new ListResourceRecordSetsCommand({
       HostedZoneId: ctx.config.hostedZoneId,
@@ -62,13 +62,13 @@ export function testCloudFrontWithDomain(ctx: CloudFrontTestContext) {
 
     assert.deepStrictEqual(
       cf.distribution.aliases,
-      [ctx.config.domainName],
+      [ctx.config.defaultDomain],
       'Aliases should be correctly configured',
     );
   });
 
   it('should have reachable distribution when domain is provided', async () => {
-    const url = `https://${ctx.config.domainName}`;
+    const url = `https://${ctx.config.defaultDomain}`;
 
     await backOff(async () => {
       const response = await request(url);

--- a/tests/cloudfront/index.test.ts
+++ b/tests/cloudfront/index.test.ts
@@ -17,19 +17,19 @@ import { testCloudFrontWithDomain } from './domain.test';
 import { testCloudFrontWithCertificate } from './certificate.test';
 import { testCloudFrontWithVariousBehaviors } from './various-behaviors.test';
 
+requireEnv('ICB_DOMAIN_NAME');
+
+const hostedZoneId = requireEnv('ICB_HOSTED_ZONE_ID');
 const programArgs: InlineProgramArgs = {
   stackName: 'dev',
   projectName: 'icb-test-cloudfront',
   program: () => import('./infrastructure'),
 };
 
-const domainName = requireEnv('ICB_DOMAIN_NAME');
-const hostedZoneId = requireEnv('ICB_HOSTED_ZONE_ID');
-
 const ctx: CloudFrontTestContext = {
   config: {
-    domainName,
     hostedZoneId,
+    defaultDomain: infraConfig.defaultDomain,
     certificateDomain: infraConfig.certificateDomain,
     certificateSANs: infraConfig.certificateSANs,
     loadBalancerDomain: infraConfig.loadBalancerDomain,

--- a/tests/cloudfront/infrastructure/config.ts
+++ b/tests/cloudfront/infrastructure/config.ts
@@ -1,10 +1,12 @@
 export const appName = 'cloudfront-test';
 
-export const certificateDomain = `sub.${process.env.ICB_DOMAIN_NAME}`;
+export const defaultDomain = `cf-dmn.${process.env.ICB_DOMAIN_NAME}`;
+
+export const certificateDomain = `cf-crt.${process.env.ICB_DOMAIN_NAME}`;
 
 export const certificateSANs = [
-  `alt1.${process.env.ICB_DOMAIN_NAME}`,
-  `alt2.${process.env.ICB_DOMAIN_NAME}`,
+  `cf-alt1.${process.env.ICB_DOMAIN_NAME}`,
+  `cf-alt2.${process.env.ICB_DOMAIN_NAME}`,
 ];
 
 export const loadBalancerDomain = `lb.${process.env.ICB_DOMAIN_NAME}`;

--- a/tests/cloudfront/infrastructure/index.ts
+++ b/tests/cloudfront/infrastructure/index.ts
@@ -6,7 +6,6 @@ import { AcmCertificate } from '../../../src/v2/components/acm-certificate';
 import * as config from './config';
 import { OriginFactory } from './origin-factory';
 
-const domainName = process.env.ICB_DOMAIN_NAME!;
 const hostedZoneId = process.env.ICB_HOSTED_ZONE_ID;
 const tags = {
   Project: pulumi.getProject(),
@@ -133,7 +132,7 @@ const cfWithDomain = new CloudFront(
   `${config.appName}-domain`,
   {
     behaviors: [{ ...cfMinimalBehavior }],
-    domain: domainName,
+    domain: config.defaultDomain,
     hostedZoneId: hostedZone.zoneId,
     tags,
   },

--- a/tests/cloudfront/test-context.ts
+++ b/tests/cloudfront/test-context.ts
@@ -6,8 +6,8 @@ import { AcmCertificate } from '../../src/v2/components/acm-certificate';
 import { AwsContext, ConfigContext, PulumiProgramContext } from '../types';
 
 interface Config {
-  domainName: string;
   hostedZoneId: string;
+  defaultDomain: string;
   certificateDomain: string;
   certificateSANs: string[];
   loadBalancerDomain: string;


### PR DESCRIPTION
Ensure CloudFront tests use prefixed subdomains to avoid clashes with other components, e.g. AcmCertificate.