### PR TITLE
test: bump `no_output_timeout` parameter to 2h

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - node/install
       - core/run_script:
           script: 'test'
-          no_output_timeout: 1h
+          no_output_timeout: 2h
 
 workflows:
   scan-and-test:


### PR DESCRIPTION
Tests are currently failing on the pipeline due to tests running longer than 1 hour without any output.
This PR bumps the `no_output_timeout` parameter to 2 hours.