### PR TITLE
fix: make CF distribution dependent on certificate validation

### DIFF
--- a/src/v2/components/acm-certificate/index.ts
+++ b/src/v2/components/acm-certificate/index.ts
@@ -16,6 +16,7 @@ export namespace AcmCertificate {
 
 export class AcmCertificate extends pulumi.ComponentResource {
   certificate: aws.acm.Certificate;
+  certificateValidation: pulumi.Output<aws.acm.CertificateValidation>;
 
   constructor(
     name: string,
@@ -35,8 +36,7 @@ export class AcmCertificate extends pulumi.ComponentResource {
       },
       { parent: this },
     );
-
-    this.createCertValidationRecords(
+    this.certificateValidation = this.createCertValidationRecords(
       args.domain,
       args.hostedZoneId,
       args.region,
@@ -50,7 +50,7 @@ export class AcmCertificate extends pulumi.ComponentResource {
     hostedZoneId: AcmCertificate.Args['hostedZoneId'],
     region: AcmCertificate.Args['region'],
   ) {
-    this.certificate.domainValidationOptions.apply(domains => {
+    return this.certificate.domainValidationOptions.apply(domains => {
       const validationRecords = domains.map(
         domain =>
           new aws.route53.Record(
@@ -69,7 +69,7 @@ export class AcmCertificate extends pulumi.ComponentResource {
           ),
       );
 
-      const certificateValidation = new aws.acm.CertificateValidation(
+      return new aws.acm.CertificateValidation(
         `${domainName}-cert-validation`,
         {
           certificateArn: this.certificate.arn,

--- a/src/v2/components/cloudfront/index.ts
+++ b/src/v2/components/cloudfront/index.ts
@@ -59,6 +59,9 @@ export class CloudFront extends pulumi.ComponentResource {
         certificate || this.acmCertificate
           ? pulumi.output(certificate ?? this.acmCertificate!.certificate)
           : undefined,
+      certificateValidation: this.acmCertificate
+        ? this.acmCertificate.certificateValidation
+        : undefined,
       defaultRootObject,
       tags,
     });
@@ -201,6 +204,7 @@ export class CloudFront extends pulumi.ComponentResource {
     orderedCaches,
     domain,
     certificate,
+    certificateValidation,
     defaultRootObject,
     tags,
   }: CreateDistributionArgs): aws.cloudfront.Distribution {
@@ -245,7 +249,13 @@ export class CloudFront extends pulumi.ComponentResource {
         },
         tags: { ...commonTags, ...tags },
       },
-      { parent: this, aliases: [{ name: `${this.name}-cloudfront` }] },
+      {
+        parent: this,
+        aliases: [{ name: `${this.name}-cloudfront` }],
+        ...(certificateValidation
+          ? { dependsOn: [certificateValidation] }
+          : undefined),
+      },
     );
   }
 
@@ -372,6 +382,7 @@ type CreateDistributionArgs = {
   orderedCaches?: aws.types.input.cloudfront.DistributionOrderedCacheBehavior[];
   domain?: pulumi.Input<string>;
   certificate?: pulumi.Output<aws.acm.Certificate>;
+  certificateValidation?: pulumi.Output<aws.acm.CertificateValidation>;
   defaultRootObject?: pulumi.Input<string>;
   tags: CloudFront.Args['tags'];
 };

--- a/tests/cloudfront/infrastructure/index.ts
+++ b/tests/cloudfront/infrastructure/index.ts
@@ -144,7 +144,7 @@ const cfWithCertificate = new studion.CloudFront(
     hostedZoneId: hostedZone.zoneId,
     tags,
   },
-  { parent },
+  { parent, dependsOn: [certificate.certificateValidation] },
 );
 const cfWithVariousBehaviors = new studion.CloudFront(
   `${config.appName}-various-behaviors`,


### PR DESCRIPTION
To avoid potential race conditions where CloudFront distribution is created before certificate is validated, which results in a error, explicit dependency is defined where the distribution depends on the certificate validation.
The `AcmCertificate` component now exposes the `certificateValidation` property for the purpose of the new dependency.