### PR TITLE
build: update `tar` for `@pulumi/pulumi` to `7.5.7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14239,9 +14239,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "overrides": {
     "@pulumi/pulumi": {
       "glob": "10.5.0",
-      "tar": "7.5.6"
+      "tar": "7.5.7"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
To resolve high severity vulnerability update overridden version of `tar` for `@pulumi/pulumi`.