### PR TITLE
refactor: export StaticSite v2 component

### DIFF
--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -10,6 +10,8 @@ export { DatabaseBuilder } from './components/database/builder';
 export { AcmCertificate } from './components/acm-certificate';
 export { Password } from './components/password';
 export { CloudFront } from './components/cloudfront';
+export { StaticSite } from './components/static-site';
+export { S3Assets } from './components/static-site/s3-assets';
 
 import { OtelCollectorBuilder } from './otel/builder';
 import { OtelCollector } from './otel';

--- a/tests/build/index.tst.ts
+++ b/tests/build/index.tst.ts
@@ -384,4 +384,28 @@ describe('Build output', () => {
       });
     });
   });
+
+  describe('StaticSite', () => {
+    it('Should export StaticSite', () => {
+      expect(studion).type.toHaveProperty('StaticSite');
+    });
+
+    it('Should export S3Assets', () => {
+      expect(studion).type.toHaveProperty('S3Assets');
+    });
+
+    describe('Instantiation', () => {
+      const { StaticSite, S3Assets } = studion;
+
+      it('Should construct StaticSite', () => {
+        expect(StaticSite).type.toBeConstructableWith('ssName', {
+          hostedZoneId: 'ZONE_ID',
+        });
+      });
+
+      it('Should construct S3Assets', () => {
+        expect(S3Assets).type.toBeConstructableWith('s3aName', {});
+      });
+    });
+  });
 });

--- a/tests/static-site/infrastructure/index.ts
+++ b/tests/static-site/infrastructure/index.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
+import { next as studion } from '@studion/infra-code-blocks';
 import * as config from './config';
-import { StaticSite } from '../../../src/v2/components/static-site';
 
 const hostedZoneId = process.env.ICB_HOSTED_ZONE_ID;
 
@@ -13,7 +13,7 @@ const hostedZone = aws.route53.getZoneOutput({
   zoneId: hostedZoneId,
 });
 
-const staticSite = new StaticSite(
+const staticSite = new studion.StaticSite(
   config.staticSiteName,
   {
     domain: config.staticSiteDomain,

--- a/tests/static-site/test-context.ts
+++ b/tests/static-site/test-context.ts
@@ -1,7 +1,7 @@
 import { CloudFrontClient } from '@aws-sdk/client-cloudfront';
 import { S3Client } from '@aws-sdk/client-s3';
+import { next as studion } from '@studion/infra-code-blocks';
 import { AwsContext, ConfigContext, PulumiProgramContext } from '../types';
-import { StaticSite } from '../../src/v2/components/static-site';
 
 interface Config {
   staticSiteName: string;
@@ -14,7 +14,7 @@ interface AwsClients {
 }
 
 export interface ProgramOutput {
-  staticSite: StaticSite;
+  staticSite: studion.StaticSite;
 }
 
 export interface StaticSiteTestContext


### PR DESCRIPTION
The StaticSite component is now available for use in v2. Add build tests for the StaticSite component.