### PR TITLE
refactor: align CloudFront and WebServer certificate behavior

### DIFF
--- a/src/v2/components/cloudfront/index.ts
+++ b/src/v2/components/cloudfront/index.ts
@@ -20,7 +20,7 @@ export class CloudFront extends pulumi.ComponentResource {
     this.name = name;
 
     const { behaviors, domain, certificate, hostedZoneId, tags } = args;
-    const hasCustomDomain = domain || certificate;
+    const hasCustomDomain = !!domain || !!certificate;
 
     if (hasCustomDomain && !hostedZoneId) {
       throw new Error(
@@ -225,10 +225,7 @@ export class CloudFront extends pulumi.ComponentResource {
                       certificate.domainName,
                       certificate.subjectAlternativeNames,
                     ])
-                    .apply(([domain, alternativeDomains]) => [
-                      domain,
-                      ...alternativeDomains,
-                    ]),
+                    .apply(([dn, sans = []]) => [...new Set([dn, ...sans])]),
               viewerCertificate: {
                 acmCertificateArn: certificate.arn,
                 sslSupportMethod: 'sni-only',

--- a/src/v2/components/web-server/builder.ts
+++ b/src/v2/components/web-server/builder.ts
@@ -1,9 +1,9 @@
 import * as pulumi from '@pulumi/pulumi';
+import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
 import { EcsService } from '../ecs-service';
 import { WebServer } from '.';
 import { OtelCollector } from '../../otel';
-import { AcmCertificate } from '../acm-certificate';
 
 export namespace WebServerBuilder {
   export type EcsConfig = Omit<WebServer.EcsConfig, 'vpc' | 'volumes'>;
@@ -26,7 +26,7 @@ export class WebServerBuilder {
   private _ecsConfig?: WebServerBuilder.EcsConfig;
   private _domain?: pulumi.Input<string>;
   private _hostedZoneId?: pulumi.Input<string>;
-  private _certificate?: pulumi.Input<AcmCertificate>;
+  private _certificate?: pulumi.Input<aws.acm.Certificate>;
   private _healthCheckPath?: pulumi.Input<string>;
   private _loadBalancingAlgorithmType?: pulumi.Input<string>;
   private _otelCollector?: pulumi.Input<OtelCollector>;

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -101,8 +101,11 @@ const webServerWithSanCertificate = new studion.WebServerBuilder(
   .configureEcs(ecs)
   .withVpc(vpc.vpc)
   .withCustomHealthCheckPath(healthCheckPath)
-  .withCertificate(sanWebServerCert, hostedZone.zoneId)
-  .build({ parent: cluster });
+  .withCertificate(sanWebServerCert.certificate, hostedZone.zoneId)
+  .build({
+    parent: cluster,
+    dependsOn: [sanWebServerCert.certificateValidation],
+  });
 
 const certWebServer = new studion.AcmCertificate(
   `${webServerName}-cert`,
@@ -119,16 +122,18 @@ const webServerWithCertificate = new studion.WebServerBuilder(`web-server-cert`)
   .withVpc(vpc.vpc)
   .withCustomHealthCheckPath(healthCheckPath)
   .withCertificate(
-    certWebServer,
+    certWebServer.certificate,
     hostedZone.zoneId,
     webServerWithCertificateConfig.primary,
   )
-  .build({ parent: cluster });
+  .build({ parent: cluster, dependsOn: [certWebServer.certificateValidation] });
 
 export {
   webServer,
   otelCollector,
+  sanWebServerCert,
   webServerWithSanCertificate,
+  certWebServer,
   webServerWithCertificate,
   webServerWithDomain,
 };


### PR DESCRIPTION
Both components now accept `aws.acm.Certificate`, wait for certificate validation, and ensure there are no duplicates when using SANs for A records. Tests are updated accordingly.