### PR TITLE
fix: proper handling of default values

### DIFF
--- a/src/v2/components/database/index.ts
+++ b/src/v2/components/database/index.ts
@@ -4,6 +4,7 @@ import * as awsx from '@pulumi/awsx-v3';
 import * as pulumi from '@pulumi/pulumi';
 import { Password } from '../password';
 import { commonTags } from '../../../constants';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export namespace Database {
   export type Instance = {
@@ -72,7 +73,7 @@ export class Database extends pulumi.ComponentResource {
 
     this.name = name;
 
-    const argsWithDefaults = Object.assign({}, defaults, args);
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
     const { vpc, kmsKeyId, enableMonitoring, snapshotIdentifier } =
       argsWithDefaults;
 

--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -3,6 +3,7 @@ import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
 import { CustomSize, Size } from '../../../types/size';
 import { PredefinedSize, commonTags } from '../../../constants';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 import { assumeRolePolicy } from './policies';
 
 const config = new pulumi.Config('aws');
@@ -192,7 +193,7 @@ export class EcsService extends pulumi.ComponentResource {
     opts: pulumi.ComponentResourceOptions = {},
   ) {
     super('studion:ecs:Service', name, {}, opts);
-    const argsWithDefaults = Object.assign({}, defaults, args);
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
     const taskExecutionRoleInlinePolicies = pulumi.output(
       args.taskExecutionRoleInlinePolicies ||
         defaults.taskExecutionRoleInlinePolicies,

--- a/src/v2/components/redis/elasticache-redis.ts
+++ b/src/v2/components/redis/elasticache-redis.ts
@@ -2,6 +2,7 @@ import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
 import * as awsx from '@pulumi/awsx-v3';
 import { commonTags } from '../../../constants';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 type RedisArgs = {
   vpc: pulumi.Input<awsx.ec2.Vpc>;
@@ -44,7 +45,7 @@ export class ElastiCacheRedis extends pulumi.ComponentResource {
     opts: pulumi.ComponentResourceOptions = {},
   ) {
     super('studion:Redis:ElastiCache', name, {}, opts);
-    const argsWithDefaults = Object.assign({}, defaults, args);
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
 
     this.name = name;
     this.vpc = pulumi.output(argsWithDefaults.vpc);

--- a/src/v2/components/redis/upstash-redis.ts
+++ b/src/v2/components/redis/upstash-redis.ts
@@ -1,6 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as upstash from '@upstash/pulumi';
 import { Password } from '../../../components/password';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export type RedisArgs = {
   dbName: pulumi.Input<string>;
@@ -37,15 +38,13 @@ export class UpstashRedis extends pulumi.ComponentResource {
   ) {
     super('studion:Redis:Upstash', name, {}, opts);
 
-    const argsWithDefaults = Object.assign({}, defaults, args);
-
-    const dbName =
-      argsWithDefaults.dbName ?? `${pulumi.getProject()}-${pulumi.getStack()}`;
+    const dbName = `${pulumi.getProject()}-${pulumi.getStack()}`;
+    const argsWithDefaults = mergeWithDefaults({ ...defaults, dbName }, args);
 
     this.instance = new upstash.RedisDatabase(
       name,
       {
-        databaseName: dbName,
+        databaseName: argsWithDefaults.dbName,
         region: argsWithDefaults.region,
         primaryRegion: argsWithDefaults.primaryRegion,
         eviction: true,

--- a/src/v2/components/vpc/index.ts
+++ b/src/v2/components/vpc/index.ts
@@ -2,6 +2,7 @@ import * as pulumi from '@pulumi/pulumi';
 import * as awsx from '@pulumi/awsx-v3';
 import { commonTags } from '../../../constants';
 import { enums } from '@pulumi/awsx-v3/types';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export type VpcArgs = {
   /**
@@ -28,7 +29,7 @@ export class Vpc extends pulumi.ComponentResource {
   ) {
     super('studion:Vpc', name, {}, opts);
 
-    const argsWithDefaults = Object.assign({}, defaults, args);
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
 
     this.vpc = new awsx.ec2.Vpc(
       `${name}-vpc`,

--- a/src/v2/components/web-server/load-balancer.ts
+++ b/src/v2/components/web-server/load-balancer.ts
@@ -2,6 +2,7 @@ import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
 import { commonTags } from '../../../constants';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export namespace WebServerLoadBalancer {
   export type Args = {
@@ -59,8 +60,9 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
 
     this.name = name;
     const vpc = pulumi.output(args.vpc);
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
     const { port, certificate, healthCheckPath, loadBalancingAlgorithmType } =
-      args;
+      argsWithDefaults;
 
     this.securityGroup = this.createLbSecurityGroup(vpc.vpcId);
 
@@ -160,7 +162,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
   private createLbTargetGroup(
     port: pulumi.Input<number>,
     vpcId: awsx.ec2.Vpc['vpcId'],
-    healthCheckPath: pulumi.Input<string> | undefined,
+    healthCheckPath: pulumi.Input<string>,
     loadBalancingAlgorithmType?: pulumi.Input<string>,
   ): aws.lb.TargetGroup {
     return new aws.lb.TargetGroup(
@@ -177,7 +179,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
           unhealthyThreshold: 2,
           interval: 60,
           timeout: 5,
-          path: healthCheckPath || defaults.healthCheckPath,
+          path: healthCheckPath,
         },
         tags: { ...commonTags, Name: `${this.name}-target-group` },
       },

--- a/src/v2/shared/merge-with-defaults.ts
+++ b/src/v2/shared/merge-with-defaults.ts
@@ -1,0 +1,10 @@
+export function mergeWithDefaults<
+  T extends Record<PropertyKey, unknown>,
+  U extends Record<PropertyKey, unknown>,
+>(defaults: T, args: U): T & U {
+  const argsWithoutUndefined = Object.fromEntries(
+    Object.entries(args).filter(([, value]) => value !== undefined),
+  ) as U;
+
+  return Object.assign({}, defaults, argsWithoutUndefined);
+}


### PR DESCRIPTION
Helper function, `mergeWithDefaults`, is now used to merge default values with arguments, ensuring that an omitted argument or one set to `undefined` does not override the default value.