### PR TITLE
refactor: migrate `commonTags` to v2

### DIFF
--- a/src/v2/components/acm-certificate/index.ts
+++ b/src/v2/components/acm-certificate/index.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 
 export namespace AcmCertificate {
   export type Args = {

--- a/src/v2/components/cloudfront/index.ts
+++ b/src/v2/components/cloudfront/index.ts
@@ -1,6 +1,6 @@
 import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { AcmCertificate } from '../acm-certificate';
 import { S3CacheStrategy } from './s3-cache-strategy';
 import { LbCacheStrategy } from './lb-cache-strategy';

--- a/src/v2/components/database/index.ts
+++ b/src/v2/components/database/index.ts
@@ -3,7 +3,7 @@ import * as awsNative from '@pulumi/aws-native';
 import * as awsx from '@pulumi/awsx-v3';
 import * as pulumi from '@pulumi/pulumi';
 import { Password } from '../password';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export namespace Database {

--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -2,7 +2,8 @@ import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
 import { CustomSize, Size } from '../../../types/size';
-import { PredefinedSize, commonTags } from '../../../constants';
+import { PredefinedSize } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 import { assumeRolePolicy } from './policies';
 

--- a/src/v2/components/password/index.ts
+++ b/src/v2/components/password/index.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
 import * as random from '@pulumi/random';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 
 export namespace Password {
   export type Args = {

--- a/src/v2/components/redis/elasticache-redis.ts
+++ b/src/v2/components/redis/elasticache-redis.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws-v7';
 import * as pulumi from '@pulumi/pulumi';
 import * as awsx from '@pulumi/awsx-v3';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export namespace ElastiCacheRedis {

--- a/src/v2/components/static-site/s3-assets.ts
+++ b/src/v2/components/static-site/s3-assets.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 
 export namespace S3Assets {
   export type Args = {

--- a/src/v2/components/vpc/index.ts
+++ b/src/v2/components/vpc/index.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as awsx from '@pulumi/awsx-v3';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { enums } from '@pulumi/awsx-v3/types';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { AcmCertificate } from '../acm-certificate';
 import { EcsService } from '../ecs-service';
 import { WebServerLoadBalancer } from './load-balancer';

--- a/src/v2/components/web-server/load-balancer.ts
+++ b/src/v2/components/web-server/load-balancer.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as aws from '@pulumi/aws-v7';
 import * as awsx from '@pulumi/awsx-v3';
-import { commonTags } from '../../../constants';
+import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
 export namespace WebServerLoadBalancer {

--- a/src/v2/shared/common-tags.ts
+++ b/src/v2/shared/common-tags.ts
@@ -1,0 +1,6 @@
+import * as pulumi from '@pulumi/pulumi';
+
+export const commonTags = {
+  Env: pulumi.getStack(),
+  Project: pulumi.getProject(),
+};


### PR DESCRIPTION
Common tags are moved to a dedicated file in the shared folder.