### PR TITLE
feat: move size to ECS task size

### DIFF
--- a/src/v2/components/ecs-service/task-size.ts
+++ b/src/v2/components/ecs-service/task-size.ts
@@ -1,0 +1,51 @@
+import * as pulumi from '@pulumi/pulumi';
+
+export type TaskSize =
+  | {
+      cpu: pulumi.Input<string>;
+      memory: pulumi.Input<string>;
+    }
+  | keyof typeof PredefinedSize;
+
+export function parseTaskSize(size: pulumi.UnwrappedObject<TaskSize>): {
+  cpu: string;
+  memory: string;
+} {
+  if (typeof size === 'string') {
+    const { cpu, memory } = PredefinedSize[size];
+
+    return { cpu: `${cpu}`, memory: `${memory}` };
+  }
+
+  return size;
+}
+
+const CPU_1_VCPU = 1024;
+const MEMORY_1GB = 1024;
+
+const PredefinedSize = {
+  small: {
+    cpu: CPU_1_VCPU / 4, // 0.25 vCPU
+    memory: MEMORY_1GB / 2, // 0.5 GB memory
+  },
+  medium: {
+    cpu: CPU_1_VCPU / 2, // 0.5 vCPU
+    memory: MEMORY_1GB, // 1 GB memory
+  },
+  large: {
+    cpu: CPU_1_VCPU, // 1 vCPU
+    memory: MEMORY_1GB * 2, // 2 GB memory
+  },
+  xlarge: {
+    cpu: CPU_1_VCPU * 2, // 2 vCPU
+    memory: MEMORY_1GB * 4, // 4 GB memory
+  },
+  '2xlarge': {
+    cpu: CPU_1_VCPU * 4, // 4 vCPU
+    memory: MEMORY_1GB * 8, // 8 GB memory
+  },
+  '3xlarge': {
+    cpu: CPU_1_VCPU * 8, // 8 vCPU
+    memory: MEMORY_1GB * 16, // 16 GB memory
+  },
+} as const;


### PR DESCRIPTION
Move `types/size` to `v2/components/ecs-service/task-size`. Logic for parsing sizes is now part of `task-size` module. Adds two new predefined sizes, `2xlarge` and `3xlarge`.