### PR TITLE
refactor: align resource types

### DIFF
--- a/src/v2/components/acm-certificate/index.ts
+++ b/src/v2/components/acm-certificate/index.ts
@@ -23,7 +23,15 @@ export class AcmCertificate extends pulumi.ComponentResource {
     args: AcmCertificate.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:acm:Certificate', name, {}, opts);
+    super(
+      'studion:acm-certificate:AcmCertificate',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:acm:Certificate' }],
+      },
+    );
 
     this.certificate = new aws.acm.Certificate(
       `${args.domain}-certificate`,

--- a/src/v2/components/cloudfront/index.ts
+++ b/src/v2/components/cloudfront/index.ts
@@ -15,7 +15,7 @@ export class CloudFront extends pulumi.ComponentResource {
     args: CloudFront.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:cf:CloudFront', name, args, opts);
+    super('studion:cloudfront:CloudFront', name, args, opts);
 
     this.name = name;
 
@@ -209,7 +209,7 @@ export class CloudFront extends pulumi.ComponentResource {
     tags,
   }: CreateDistributionArgs): aws.cloudfront.Distribution {
     return new aws.cloudfront.Distribution(
-      `${this.name}-cloudfront-distribution`,
+      `${this.name}-distribution`,
       {
         enabled: true,
         isIpv6Enabled: true,

--- a/src/v2/components/cloudfront/lb-cache-strategy.ts
+++ b/src/v2/components/cloudfront/lb-cache-strategy.ts
@@ -24,7 +24,7 @@ export class LbCacheStrategy
     args: LbCacheStrategy.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:cf:LbCacheStrategy', name, args, opts);
+    super('studion:cloudfront:LbCacheStrategy', name, args, opts);
 
     this.name = name;
 
@@ -60,7 +60,7 @@ export class LbCacheStrategy
 
   private createCachePolicy() {
     return new aws.cloudfront.CachePolicy(
-      `${this.name}-lb-cache-policy`,
+      `${this.name}-cache-policy`,
       {
         defaultTtl: 0,
         minTtl: 0,
@@ -85,7 +85,7 @@ export class LbCacheStrategy
 
   private createResponseHeadersPolicy() {
     return new aws.cloudfront.ResponseHeadersPolicy(
-      `${this.name}-lb-res-headers-policy`,
+      `${this.name}-res-headers-policy`,
       {
         customHeadersConfig: {
           items: [

--- a/src/v2/components/cloudfront/s3-cache-strategy.ts
+++ b/src/v2/components/cloudfront/s3-cache-strategy.ts
@@ -24,7 +24,7 @@ export class S3CacheStrategy
     args: S3CacheStrategy.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:cf:S3CacheStrategy', name, args, opts);
+    super('studion:cloudfront:S3CacheStrategy', name, args, opts);
 
     this.name = name;
 
@@ -49,7 +49,7 @@ export class S3CacheStrategy
 
   private createCachePolicy() {
     return new aws.cloudfront.CachePolicy(
-      `${this.name}-s3-cache-policy`,
+      `${this.name}-cache-policy`,
       {
         defaultTtl: 86400, // 1 day
         minTtl: 60, // 1 minute
@@ -74,7 +74,7 @@ export class S3CacheStrategy
 
   private createResponseHeadersPolicy() {
     return new aws.cloudfront.ResponseHeadersPolicy(
-      `${this.name}-s3-res-headers-policy`,
+      `${this.name}-res-headers-policy`,
       {
         customHeadersConfig: {
           items: [

--- a/src/v2/components/database/database-replica.ts
+++ b/src/v2/components/database/database-replica.ts
@@ -55,7 +55,15 @@ export class DatabaseReplica extends pulumi.ComponentResource {
     args: DatabaseReplica.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:DatabaseReplica', name, {}, opts);
+    super(
+      'studion:database:DatabaseReplica',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:DatabaseReplica' }],
+      },
+    );
 
     this.name = name;
 

--- a/src/v2/components/database/ec2-ssm-connect.ts
+++ b/src/v2/components/database/ec2-ssm-connect.ts
@@ -38,7 +38,18 @@ export class Ec2SSMConnect extends pulumi.ComponentResource {
     args: Ec2SSMConnect.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Ec2SSMConnect', name, {}, opts);
+    super(
+      'studion:database:Ec2SSMConnect',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [
+          ...(opts.aliases || []),
+          { type: 'studion:Ec2BastionSSMConnect' },
+        ],
+      },
+    );
 
     const { vpc, instanceType, tags } = mergeWithDefaults(defaults, args);
 

--- a/src/v2/components/database/index.ts
+++ b/src/v2/components/database/index.ts
@@ -93,7 +93,15 @@ export class Database extends pulumi.ComponentResource {
     args: Database.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Database', name, {}, opts);
+    super(
+      'studion:database:Database',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:Database' }],
+      },
+    );
 
     this.name = name;
 

--- a/src/v2/components/ecs-service/index.ts
+++ b/src/v2/components/ecs-service/index.ts
@@ -193,7 +193,15 @@ export class EcsService extends pulumi.ComponentResource {
     args: EcsService.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:ecs:Service', name, {}, opts);
+    super(
+      'studion:ecs-service:EcsService',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:ecs:Service' }],
+      },
+    );
     const argsWithDefaults = mergeWithDefaults(defaults, args);
     const taskExecutionRoleInlinePolicies = pulumi.output(
       args.taskExecutionRoleInlinePolicies ||

--- a/src/v2/components/password/index.ts
+++ b/src/v2/components/password/index.ts
@@ -19,7 +19,15 @@ export class Password extends pulumi.ComponentResource {
     args: Password.Args = {},
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Password', name, {}, opts);
+    super(
+      'studion:password:Password',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:Password' }],
+      },
+    );
 
     this.name = name;
     if (args.value) {

--- a/src/v2/components/redis/elasticache-redis.ts
+++ b/src/v2/components/redis/elasticache-redis.ts
@@ -46,7 +46,7 @@ export class ElastiCacheRedis extends pulumi.ComponentResource {
     args: ElastiCacheRedis.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Redis:ElastiCache', name, {}, opts);
+    super('studion:redis:ElastiCacheRedis', name, {}, opts);
     const argsWithDefaults = mergeWithDefaults(defaults, args);
 
     this.name = name;

--- a/src/v2/components/redis/upstash-redis.ts
+++ b/src/v2/components/redis/upstash-redis.ts
@@ -38,7 +38,15 @@ export class UpstashRedis extends pulumi.ComponentResource {
     args: UpstashRedis.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Redis:Upstash', name, {}, opts);
+    super(
+      'studion:redis:UpstashRedis',
+      name,
+      {},
+      {
+        ...opts,
+        aliases: [...(opts.aliases || []), { type: 'studion:Redis' }],
+      },
+    );
 
     const dbName = `${pulumi.getProject()}-${pulumi.getStack()}`;
     const argsWithDefaults = mergeWithDefaults({ ...defaults, dbName }, args);

--- a/src/v2/components/static-site/index.ts
+++ b/src/v2/components/static-site/index.ts
@@ -34,7 +34,7 @@ export class StaticSite extends pulumi.ComponentResource {
     args: StaticSite.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:ss:StaticSite', name, args, {
+    super('studion:static-site:StaticSite', name, args, {
       ...opts,
       aliases: [...(opts.aliases || []), { type: 'studion:StaticSite' }],
     });

--- a/src/v2/components/static-site/s3-assets.ts
+++ b/src/v2/components/static-site/s3-assets.ts
@@ -22,7 +22,7 @@ export class S3Assets extends pulumi.ComponentResource {
     args: S3Assets.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:ss:S3Assets', name, args, opts);
+    super('studion:static-site:S3Assets', name, args, opts);
 
     this.name = name;
 

--- a/src/v2/components/vpc/index.ts
+++ b/src/v2/components/vpc/index.ts
@@ -27,7 +27,7 @@ export class Vpc extends pulumi.ComponentResource {
     args: VpcArgs,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:Vpc', name, {}, opts);
+    super('studion:vpc:Vpc', name, {}, opts);
 
     const argsWithDefaults = mergeWithDefaults(defaults, args);
 

--- a/src/v2/components/web-server/index.ts
+++ b/src/v2/components/web-server/index.ts
@@ -100,7 +100,10 @@ export class WebServer extends pulumi.ComponentResource {
     args: WebServer.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:WebServer', name, args, opts);
+    super('studion:web-server:WebServer', name, args, {
+      ...opts,
+      aliases: [...(opts.aliases || []), { type: 'studion:WebServer' }],
+    });
     const { vpc, domain, hostedZoneId, certificate } = args;
     const hasCustomDomain = !!domain || !!certificate;
 

--- a/src/v2/components/web-server/load-balancer.ts
+++ b/src/v2/components/web-server/load-balancer.ts
@@ -56,7 +56,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
     args: WebServerLoadBalancer.Args,
     opts: pulumi.ComponentResourceOptions = {},
   ) {
-    super('studion:WebServerLoadBalancer', name, args, opts);
+    super('studion:web-server:WebServerLoadBalancer', name, args, opts);
 
     this.name = name;
     const vpc = pulumi.output(args.vpc);


### PR DESCRIPTION
Component resources is now standardized to `studion:{module}:{class-name}` to be inline with pulumi recommendations. Aliases are update accordingly.