### PR TITLE
feat: add CloudFront S3 behavior cache TTL option

### DIFF
--- a/src/components/cloudfront/index.ts
+++ b/src/components/cloudfront/index.ts
@@ -127,7 +127,11 @@ export class CloudFront extends pulumi.ComponentResource {
     if (isS3BehaviorType(behavior)) {
       const strategy = new S3CacheStrategy(
         getStrategyName('s3'),
-        { pathPattern: behavior.pathPattern, bucket: behavior.bucket },
+        {
+          pathPattern: behavior.pathPattern,
+          bucket: behavior.bucket,
+          cacheTtl: behavior.cacheTtl,
+        },
         { parent: this },
       );
 
@@ -301,6 +305,11 @@ export namespace CloudFront {
     type: BehaviorType.S3;
     bucket: pulumi.Input<aws.s3.Bucket>;
     websiteConfig: pulumi.Input<aws.s3.BucketWebsiteConfiguration>;
+    /**
+     * Override TTLs of the default cache policy. Suitable when more control is
+     * needed to set up unified TTL on the default cache policy.
+     */
+    cacheTtl?: pulumi.Input<number>;
   };
 
   export type LbBehavior = BehaviorBase & {

--- a/tests/cloudfront/index.test.ts
+++ b/tests/cloudfront/index.test.ts
@@ -41,6 +41,8 @@ const ctx: CloudFrontTestContext = {
       infraConfig.cfWithVariousBehaviorsLbPathPattern,
     cfWithVariousBehaviorsS3PathPattern:
       infraConfig.cfWithVariousBehaviorsS3PathPattern,
+    cfWithVariousBehaviorsS3TtlPathPattern:
+      infraConfig.cfWithVariousBehaviorsS3TtlPathPattern,
     cfWithVariousBehaviorsCustomOriginProtocolPolicy:
       infraConfig.cfWithVariousBehaviorsCustomOriginProtocolPolicy,
     cfWithVariousBehaviorsCustomDefaultRootObject:

--- a/tests/cloudfront/infrastructure/config.ts
+++ b/tests/cloudfront/infrastructure/config.ts
@@ -1,6 +1,7 @@
 export const appName = 'cloudfront-test';
 
 export const baseDomain = `cf.${process.env.ICB_DOMAIN_NAME}`;
+
 export const defaultDomain = `dmn.${baseDomain}`;
 
 export const certificateDomain = `crt.${baseDomain}`;
@@ -20,6 +21,8 @@ export const cfMinimalDefaultRootObject = 'index.html';
 export const cfWithVariousBehaviorsLbPathPattern = '/api/*';
 
 export const cfWithVariousBehaviorsS3PathPattern = '/www/*';
+
+export const cfWithVariousBehaviorsS3TtlPathPattern = '/www-ttl/*';
 
 export const cfWithVariousBehaviorsCustomOriginProtocolPolicy = 'http-only';
 

--- a/tests/cloudfront/infrastructure/index.ts
+++ b/tests/cloudfront/infrastructure/index.ts
@@ -35,6 +35,9 @@ const [s3WebsiteBucket, s3WebsiteBucketConfig] = originFactory.getWebsiteBucket(
   's3-site',
   'www/',
 );
+const [s3TtlWebsiteBucket, s3TtlWebsiteBucketConfig] =
+  originFactory.getWebsiteBucket('s3-ttl-site', 'www-ttl/');
+
 const loadBalancer = originFactory.getLoadBalancer(
   'ws',
   vpc.vpc,
@@ -164,6 +167,13 @@ const cfWithVariousBehaviors = new studion.CloudFront(
         websiteConfig: s3WebsiteBucketConfig,
       },
       {
+        type: studion.CloudFront.BehaviorType.S3,
+        pathPattern: config.cfWithVariousBehaviorsS3TtlPathPattern,
+        bucket: s3TtlWebsiteBucket,
+        websiteConfig: s3TtlWebsiteBucketConfig,
+        cacheTtl: 0,
+      },
+      {
         type: studion.CloudFront.BehaviorType.CUSTOM,
         pathPattern: '*',
         originId: customWebsiteBucket.id,
@@ -192,6 +202,7 @@ export {
   loadBalancer,
   s3WebsiteBucket,
   s3WebsiteBucketConfig,
+  s3TtlWebsiteBucket,
   customWebsiteBucket,
   customWebsiteBucketConfig,
   customCachePolicy,

--- a/tests/cloudfront/test-context.ts
+++ b/tests/cloudfront/test-context.ts
@@ -16,6 +16,7 @@ interface Config {
   cfMinimalDefaultRootObject: string;
   cfWithVariousBehaviorsLbPathPattern: string;
   cfWithVariousBehaviorsS3PathPattern: string;
+  cfWithVariousBehaviorsS3TtlPathPattern: string;
   cfWithVariousBehaviorsCustomOriginProtocolPolicy: string;
   cfWithVariousBehaviorsCustomDefaultRootObject: string;
   cfWithVariousBehaviorsCustomAllowedMethods: string[];
@@ -36,6 +37,7 @@ export interface ProgramOutput {
   loadBalancer: aws.lb.LoadBalancer;
   s3WebsiteBucket: aws.s3.Bucket;
   s3WebsiteBucketConfig: aws.s3.BucketWebsiteConfiguration;
+  s3TtlWebsiteBucket: aws.s3.Bucket;
   customWebsiteBucket: aws.s3.Bucket;
   customWebsiteBucketConfig: aws.s3.BucketWebsiteConfiguration;
   customCachePolicy: aws.cloudfront.CachePolicy;


### PR DESCRIPTION
CloudFront S3 behavior now accepts the `cacheTtl` option to override default's cache policy TTLs. The `cacheTtl` value is set as default, min and max TTL on the default cache policy.