### PR TITLE
feat: grafana token creation

### DIFF
--- a/src/components/grafana/builder.ts
+++ b/src/components/grafana/builder.ts
@@ -17,6 +17,8 @@ export class GrafanaBuilder {
     [];
   private readonly scopes: string[] = [];
   private folderName?: string;
+  private serviceAccountTokenRotation?: Grafana.ServiceAccountTokenRotation;
+  private accessPolicyTokenRotation?: Grafana.AccessPolicyTokenRotation;
 
   constructor(name: string) {
     this.name = name;
@@ -24,6 +26,22 @@ export class GrafanaBuilder {
 
   public withFolderName(folderName: string): this {
     this.folderName = folderName;
+
+    return this;
+  }
+
+  public withServiceAccountTokenRotation(
+    rotation: Grafana.ServiceAccountTokenRotation,
+  ): this {
+    this.serviceAccountTokenRotation = rotation;
+
+    return this;
+  }
+
+  public withAccessPolicyTokenRotation(
+    rotation: Grafana.AccessPolicyTokenRotation,
+  ): this {
+    this.accessPolicyTokenRotation = rotation;
 
     return this;
   }
@@ -102,6 +120,8 @@ export class GrafanaBuilder {
         dashboardBuilders: this.dashboardBuilders,
         folderName: this.folderName,
         scopes: this.scopes,
+        serviceAccountTokenRotation: this.serviceAccountTokenRotation,
+        accessPolicyTokenRotation: this.accessPolicyTokenRotation,
       },
       opts,
     );

--- a/src/components/grafana/builder.ts
+++ b/src/components/grafana/builder.ts
@@ -15,6 +15,7 @@ export class GrafanaBuilder {
     [];
   private readonly dashboardBuilders: GrafanaDashboardBuilder.CreateDashboard[] =
     [];
+  private readonly scopes: string[] = [];
   private folderName?: string;
 
   constructor(name: string) {
@@ -27,25 +28,36 @@ export class GrafanaBuilder {
     return this;
   }
 
-  public addAmp(name: string, args: AMPConnection.Args): this {
-    this.connectionBuilders.push(opts => new AMPConnection(name, args, opts));
+  public addScope(...scopes: string[]): this {
+    this.scopes.push(...scopes);
+
+    return this;
+  }
+
+  public addAmp(name: string, args: Omit<AMPConnection.Args, 'stack'>): this {
+    this.connectionBuilders.push(
+      (ctx, opts) => new AMPConnection(name, { ...args, ...ctx }, opts),
+    );
 
     return this;
   }
 
   public addCLoudWatchLogs(
     name: string,
-    args: CloudWatchLogsConnection.Args,
+    args: Omit<CloudWatchLogsConnection.Args, 'stack'>,
   ): this {
     this.connectionBuilders.push(
-      opts => new CloudWatchLogsConnection(name, args, opts),
+      (ctx, opts) =>
+        new CloudWatchLogsConnection(name, { ...args, ...ctx }, opts),
     );
 
     return this;
   }
 
-  public addXRay(name: string, args: XRayConnection.Args): this {
-    this.connectionBuilders.push(opts => new XRayConnection(name, args, opts));
+  public addXRay(name: string, args: Omit<XRayConnection.Args, 'stack'>): this {
+    this.connectionBuilders.push(
+      (ctx, opts) => new XRayConnection(name, { ...args, ...ctx }, opts),
+    );
 
     return this;
   }
@@ -89,6 +101,7 @@ export class GrafanaBuilder {
         connectionBuilders: this.connectionBuilders,
         dashboardBuilders: this.dashboardBuilders,
         folderName: this.folderName,
+        scopes: this.scopes,
       },
       opts,
     );

--- a/src/components/grafana/connections/amp-connection.ts
+++ b/src/components/grafana/connections/amp-connection.ts
@@ -85,7 +85,7 @@ export class AMPConnection extends GrafanaConnection {
     return new grafana.cloud.PluginInstallation(
       `${this.name}-amp-plugin`,
       {
-        stackSlug: this.getStackSlug(),
+        stackSlug: this.stack.slug,
         slug: pluginName,
         version: pluginVersion,
       },

--- a/src/components/grafana/connections/connection.ts
+++ b/src/components/grafana/connections/connection.ts
@@ -3,15 +3,17 @@ import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
 import { commonTags } from '../../../shared/common-tags';
 
-const grafanaConfig = new pulumi.Config('grafana');
-
 export namespace GrafanaConnection {
   export type Args = {
     awsAccountId: string;
     dataSourceName?: string;
+    stack: pulumi.Input<grafana.cloud.GetStackResult>;
   };
 
+  export type CreateConnectionContext = Pick<Args, 'stack'>;
+
   export type CreateConnection = (
+    ctx: CreateConnectionContext,
     opts: pulumi.ComponentResourceOptions,
   ) => GrafanaConnection;
 }
@@ -21,6 +23,7 @@ export abstract class GrafanaConnection extends pulumi.ComponentResource {
   public readonly role: aws.iam.Role;
   public abstract readonly dataSource: grafana.oss.DataSource;
   protected readonly dataSourceName: string;
+  protected readonly stack: pulumi.Output<grafana.cloud.GetStackResult>;
 
   constructor(
     type: string,
@@ -31,30 +34,14 @@ export abstract class GrafanaConnection extends pulumi.ComponentResource {
     super(type, name, {}, opts);
 
     this.name = name;
-
     this.dataSourceName = args.dataSourceName ?? `${name}-datasource`;
-
+    this.stack = pulumi.output(args.stack);
     this.role = this.createIamRole(args.awsAccountId);
 
     this.registerOutputs();
   }
 
-  protected getStackSlug(): string {
-    const grafanaUrl = grafanaConfig.get('url') ?? process.env.GRAFANA_URL;
-
-    if (!grafanaUrl) {
-      throw new Error(
-        'Grafana URL is not configured. Set it via Pulumi config (grafana:url) or GRAFANA_URL env var.',
-      );
-    }
-
-    return new URL(grafanaUrl).hostname.split('.')[0];
-  }
-
   private createIamRole(awsAccountId: string): aws.iam.Role {
-    const stackSlug = this.getStackSlug();
-    const grafanaStack = grafana.cloud.getStack({ slug: stackSlug });
-
     const assumeRolePolicy = aws.iam.getPolicyDocumentOutput({
       statements: [
         {
@@ -70,7 +57,7 @@ export abstract class GrafanaConnection extends pulumi.ComponentResource {
             {
               test: 'StringEquals',
               variable: 'sts:ExternalId',
-              values: [pulumi.output(grafanaStack).id],
+              values: [this.stack.id],
             },
           ],
         },

--- a/src/components/grafana/connections/xray-connection.ts
+++ b/src/components/grafana/connections/xray-connection.ts
@@ -86,7 +86,7 @@ export class XRayConnection extends GrafanaConnection {
     return new grafana.cloud.PluginInstallation(
       `${this.name}-x-ray-plugin`,
       {
-        stackSlug: this.getStackSlug(),
+        stackSlug: this.stack.slug,
         slug: pluginName,
         version: pluginVersion,
       },

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -3,6 +3,11 @@ import * as grafana from '@pulumiverse/grafana';
 import type { GrafanaDashboardBuilder } from './dashboards/builder';
 import { GrafanaConnection } from './connections';
 
+/**
+ * Requires a predefined GRAFANA_CLOUD_ACCESS_POLICY_TOKEN with the following scopes:
+ * accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write
+ */
+
 export namespace Grafana {
   export type Args = {
     connectionBuilders: GrafanaConnection.CreateConnection[];

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -2,8 +2,9 @@ import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
 import type { GrafanaDashboardBuilder } from './dashboards/builder';
 import { GrafanaConnection } from './connections';
+import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
-const DEFAULT_ACCESS_POLICY_SCOPES = [
+const REQUIRED_ACCESS_POLICY_SCOPES = [
   'accesspolicies:read',
   'accesspolicies:write',
   'accesspolicies:delete',
@@ -19,12 +20,35 @@ const DEFAULT_ACCESS_POLICY_SCOPES = [
   'stack-plugins:delete',
 ] as const;
 
+const defaults = {
+  serviceAccountTokenRotation: {
+    secondsToLive: 7_776_000, // 90 days
+    earlyRotationWindowSeconds: 604_800, // 7 days
+  },
+  accessPolicyTokenRotation: {
+    expireAfter: '2160h', // 90 days
+    earlyRotationWindow: '168h', // 7 days
+  },
+};
+
 export namespace Grafana {
+  export type ServiceAccountTokenRotation = {
+    secondsToLive: number;
+    earlyRotationWindowSeconds: number;
+  };
+
+  export type AccessPolicyTokenRotation = {
+    expireAfter: string;
+    earlyRotationWindow: string;
+  };
+
   export type Args = {
     connectionBuilders: GrafanaConnection.CreateConnection[];
     dashboardBuilders: GrafanaDashboardBuilder.CreateDashboard[];
     folderName?: string;
     scopes?: string[];
+    serviceAccountTokenRotation?: ServiceAccountTokenRotation;
+    accessPolicyTokenRotation?: AccessPolicyTokenRotation;
   };
 }
 
@@ -52,30 +76,36 @@ export class Grafana extends pulumi.ComponentResource {
   ) {
     super('studion:grafana:Grafana', name, {}, opts);
 
+    const argsWithDefaults = mergeWithDefaults(defaults, args);
+
     this.name = name;
 
     this.stack = grafana.cloud.getStackOutput({ slug: this.getStackSlug() });
 
-    this.accessPolicy = this.createAccessPolicy(args.scopes);
-    const accessPolicyToken = this.createAccessPolicyToken();
+    this.accessPolicy = this.createAccessPolicy(argsWithDefaults.scopes);
+    const accessPolicyToken = this.createAccessPolicyToken(
+      argsWithDefaults.accessPolicyTokenRotation,
+    );
     this.accessPolicyToken = pulumi.secret(accessPolicyToken.token);
 
     this.serviceAccount = this.createServiceAccount();
-    const serviceAccountToken = this.createServiceAccountToken();
+    const serviceAccountToken = this.createServiceAccountToken(
+      argsWithDefaults.serviceAccountTokenRotation,
+    );
     this.serviceAccountToken = pulumi.secret(serviceAccountToken.key);
 
     this.provider = this.createProvider();
 
-    this.connections = args.connectionBuilders.map(build => {
+    this.connections = argsWithDefaults.connectionBuilders.map(build => {
       return build(
         { stack: this.stack },
         { parent: this, provider: this.provider },
       );
     });
 
-    this.folder = this.createFolder(args.folderName, this.provider);
+    this.folder = this.createFolder(argsWithDefaults.folderName, this.provider);
 
-    this.dashboards = args.dashboardBuilders.map(build => {
+    this.dashboards = argsWithDefaults.dashboardBuilders.map(build => {
       return build(this.folder, {
         parent: this.folder,
         provider: this.provider,
@@ -105,7 +135,7 @@ export class Grafana extends pulumi.ComponentResource {
         region: this.stack.regionSlug,
         name: `${this.name}-access-policy`,
         scopes: [
-          ...new Set([...DEFAULT_ACCESS_POLICY_SCOPES, ...(scopes ?? [])]),
+          ...new Set([...REQUIRED_ACCESS_POLICY_SCOPES, ...(scopes ?? [])]),
         ],
         realms: [{ type: 'stack', identifier: this.stack.id }],
       },
@@ -113,15 +143,17 @@ export class Grafana extends pulumi.ComponentResource {
     );
   }
 
-  private createAccessPolicyToken(): grafana.cloud.AccessPolicyRotatingToken {
+  private createAccessPolicyToken(
+    rotation: Grafana.AccessPolicyTokenRotation,
+  ): grafana.cloud.AccessPolicyRotatingToken {
     return new grafana.cloud.AccessPolicyRotatingToken(
       `${this.name}-access-policy-token`,
       {
         region: this.stack.regionSlug,
         accessPolicyId: this.accessPolicy.policyId,
         namePrefix: `${this.name}-icb-access-policy-token-${pulumi.getStack()}`,
-        expireAfter: '2160h', // 90 days
-        earlyRotationWindow: '168h', // 7 days before expiry
+        expireAfter: rotation.expireAfter,
+        earlyRotationWindow: rotation.earlyRotationWindow,
         deleteOnDestroy: true,
       },
       { parent: this },
@@ -140,15 +172,17 @@ export class Grafana extends pulumi.ComponentResource {
     );
   }
 
-  private createServiceAccountToken(): grafana.cloud.StackServiceAccountRotatingToken {
+  private createServiceAccountToken(
+    rotation: Grafana.ServiceAccountTokenRotation,
+  ): grafana.cloud.StackServiceAccountRotatingToken {
     return new grafana.cloud.StackServiceAccountRotatingToken(
       `${this.name}-service-account-token`,
       {
         stackSlug: this.stack.slug,
         serviceAccountId: this.serviceAccount.id,
         namePrefix: `${this.name}-icb-service-account-token-${pulumi.getStack()}`,
-        secondsToLive: 7_776_000, // 90 days
-        earlyRotationWindowSeconds: 604_800, // 7 days before expiry
+        secondsToLive: rotation.secondsToLive,
+        earlyRotationWindowSeconds: rotation.earlyRotationWindowSeconds,
         deleteOnDestroy: true,
       },
       { parent: this },

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -3,10 +3,21 @@ import * as grafana from '@pulumiverse/grafana';
 import type { GrafanaDashboardBuilder } from './dashboards/builder';
 import { GrafanaConnection } from './connections';
 
-/**
- * Requires a predefined GRAFANA_CLOUD_ACCESS_POLICY_TOKEN with the following scopes:
- * accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write
- */
+const DEFAULT_ACCESS_POLICY_SCOPES = [
+  'accesspolicies:read',
+  'accesspolicies:write',
+  'accesspolicies:delete',
+  'datasources:read',
+  'datasources:write',
+  'datasources:delete',
+  'stacks:read',
+  'stack-dashboards:read',
+  'stack-dashboards:write',
+  'stack-dashboards:delete',
+  'stack-plugins:read',
+  'stack-plugins:write',
+  'stack-plugins:delete',
+] as const;
 
 export namespace Grafana {
   export type Args = {
@@ -17,6 +28,10 @@ export namespace Grafana {
   };
 }
 
+/**
+ * This component requires a predefined GRAFANA_CLOUD_ACCESS_POLICY_TOKEN with the following scopes:
+ * accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write
+ */
 export class Grafana extends pulumi.ComponentResource {
   public readonly name: string;
   public readonly stack: pulumi.Output<grafana.cloud.GetStackResult>;
@@ -89,22 +104,7 @@ export class Grafana extends pulumi.ComponentResource {
         region: this.stack.regionSlug,
         name: `${this.name}-access-policy`,
         scopes: [
-          ...new Set([
-            'accesspolicies:read',
-            'accesspolicies:write',
-            'accesspolicies:delete',
-            'datasources:read',
-            'datasources:write',
-            'datasources:delete',
-            'stacks:read',
-            'stack-dashboards:read',
-            'stack-dashboards:write',
-            'stack-dashboards:delete',
-            'stack-plugins:read',
-            'stack-plugins:write',
-            'stack-plugins:delete',
-            ...(scopes ?? []),
-          ]),
+          ...new Set([...DEFAULT_ACCESS_POLICY_SCOPES, ...(scopes ?? [])]),
         ],
         realms: [{ type: 'stack', identifier: this.stack.id }],
       },

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -29,7 +29,8 @@ export namespace Grafana {
 }
 
 /**
- * This component requires a predefined GRAFANA_CLOUD_ACCESS_POLICY_TOKEN with the following scopes:
+ * This component requires a grafana cloud access policy token to be created and set
+ * as `GRAFANA_CLOUD_ACCESS_POLICY_TOKEN` with the following scopes:
  * accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write
  */
 export class Grafana extends pulumi.ComponentResource {

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -113,13 +113,16 @@ export class Grafana extends pulumi.ComponentResource {
     );
   }
 
-  private createAccessPolicyToken(): grafana.cloud.AccessPolicyToken {
-    return new grafana.cloud.AccessPolicyToken(
+  private createAccessPolicyToken(): grafana.cloud.AccessPolicyRotatingToken {
+    return new grafana.cloud.AccessPolicyRotatingToken(
       `${this.name}-access-policy-token`,
       {
         region: this.stack.regionSlug,
         accessPolicyId: this.accessPolicy.policyId,
-        name: `${this.name}-icb-access-policy-token-${pulumi.getStack()}`,
+        namePrefix: `${this.name}-icb-access-policy-token-${pulumi.getStack()}`,
+        expireAfter: '2160h', // 90 days
+        earlyRotationWindow: '168h', // 7 days before expiry
+        deleteOnDestroy: true,
       },
       { parent: this },
     );
@@ -137,13 +140,16 @@ export class Grafana extends pulumi.ComponentResource {
     );
   }
 
-  private createServiceAccountToken(): grafana.cloud.StackServiceAccountToken {
-    return new grafana.cloud.StackServiceAccountToken(
+  private createServiceAccountToken(): grafana.cloud.StackServiceAccountRotatingToken {
+    return new grafana.cloud.StackServiceAccountRotatingToken(
       `${this.name}-service-account-token`,
       {
         stackSlug: this.stack.slug,
         serviceAccountId: this.serviceAccount.id,
-        name: `${this.name}-icb-service-account-token-${pulumi.getStack()}`,
+        namePrefix: `${this.name}-icb-service-account-token-${pulumi.getStack()}`,
+        secondsToLive: 7_776_000, // 90 days
+        earlyRotationWindowSeconds: 604_800, // 7 days before expiry
+        deleteOnDestroy: true,
       },
       { parent: this },
     );

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -8,11 +8,18 @@ export namespace Grafana {
     connectionBuilders: GrafanaConnection.CreateConnection[];
     dashboardBuilders: GrafanaDashboardBuilder.CreateDashboard[];
     folderName?: string;
+    scopes?: string[];
   };
 }
 
 export class Grafana extends pulumi.ComponentResource {
   public readonly name: string;
+  public readonly stack: pulumi.Output<grafana.cloud.GetStackResult>;
+  public readonly accessPolicy: grafana.cloud.AccessPolicy;
+  public readonly accessPolicyToken: pulumi.Output<string>;
+  public readonly serviceAccount: grafana.cloud.StackServiceAccount;
+  public readonly serviceAccountToken: pulumi.Output<string>;
+  public readonly provider: grafana.Provider;
   public readonly connections: GrafanaConnection[];
   public readonly folder: grafana.oss.Folder;
   public readonly dashboards: grafana.oss.Dashboard[];
@@ -26,20 +33,136 @@ export class Grafana extends pulumi.ComponentResource {
 
     this.name = name;
 
+    this.stack = grafana.cloud.getStackOutput({ slug: this.getStackSlug() });
+
+    this.accessPolicy = this.createAccessPolicy(args.scopes);
+    const accessPolicyToken = this.createAccessPolicyToken();
+    this.accessPolicyToken = pulumi.secret(accessPolicyToken.token);
+
+    this.serviceAccount = this.createServiceAccount();
+    const serviceAccountToken = this.createServiceAccountToken();
+    this.serviceAccountToken = pulumi.secret(serviceAccountToken.key);
+
+    this.provider = this.createProvider();
+
     this.connections = args.connectionBuilders.map(build => {
-      return build({ parent: this });
+      return build(
+        { stack: this.stack },
+        { parent: this, provider: this.provider },
+      );
     });
 
-    this.folder = new grafana.oss.Folder(
-      `${this.name}-folder`,
-      { title: args.folderName ?? `${this.name}-ICB-GENERATED` },
-      { parent: this },
-    );
+    this.folder = this.createFolder(args.folderName, this.provider);
 
     this.dashboards = args.dashboardBuilders.map(build => {
-      return build(this.folder, { parent: this.folder });
+      return build(this.folder, {
+        parent: this.folder,
+        provider: this.provider,
+      });
     });
 
     this.registerOutputs();
+  }
+
+  private getStackSlug(): string {
+    const grafanaConfig = new pulumi.Config('grafana');
+    const grafanaUrl = grafanaConfig.get('url') ?? process.env.GRAFANA_URL;
+
+    if (!grafanaUrl) {
+      throw new Error(
+        'Grafana URL is not configured. Set it via Pulumi config (grafana:url) or GRAFANA_URL env var.',
+      );
+    }
+
+    return new URL(grafanaUrl).hostname.split('.')[0];
+  }
+
+  private createAccessPolicy(scopes?: string[]): grafana.cloud.AccessPolicy {
+    return new grafana.cloud.AccessPolicy(
+      `${this.name}-access-policy`,
+      {
+        region: this.stack.regionSlug,
+        name: `${this.name}-access-policy`,
+        scopes: [
+          ...new Set([
+            'accesspolicies:read',
+            'accesspolicies:write',
+            'accesspolicies:delete',
+            'datasources:read',
+            'datasources:write',
+            'datasources:delete',
+            'stacks:read',
+            'stack-dashboards:read',
+            'stack-dashboards:write',
+            'stack-dashboards:delete',
+            'stack-plugins:read',
+            'stack-plugins:write',
+            'stack-plugins:delete',
+            ...(scopes ?? []),
+          ]),
+        ],
+        realms: [{ type: 'stack', identifier: this.stack.id }],
+      },
+      { parent: this },
+    );
+  }
+
+  private createAccessPolicyToken(): grafana.cloud.AccessPolicyToken {
+    return new grafana.cloud.AccessPolicyToken(
+      `${this.name}-cloud-token`,
+      {
+        region: this.stack.regionSlug,
+        accessPolicyId: this.accessPolicy.policyId,
+        name: `${this.name}-cloud-token`,
+      },
+      { parent: this },
+    );
+  }
+
+  private createServiceAccount(): grafana.cloud.StackServiceAccount {
+    return new grafana.cloud.StackServiceAccount(
+      `${this.name}-sa`,
+      {
+        stackSlug: this.stack.slug,
+        name: `${this.name}-sa`,
+        role: 'Admin',
+      },
+      { parent: this },
+    );
+  }
+
+  private createServiceAccountToken(): grafana.cloud.StackServiceAccountToken {
+    return new grafana.cloud.StackServiceAccountToken(
+      `${this.name}-sa-token`,
+      {
+        stackSlug: this.stack.slug,
+        serviceAccountId: this.serviceAccount.id,
+        name: `${this.name}-sa-token`,
+      },
+      { parent: this },
+    );
+  }
+
+  private createFolder(
+    folderName: string | undefined,
+    provider: grafana.Provider,
+  ): grafana.oss.Folder {
+    return new grafana.oss.Folder(
+      `${this.name}-folder`,
+      { title: folderName ?? `${this.name}-ICB-GENERATED` },
+      { parent: this, provider },
+    );
+  }
+
+  private createProvider(): grafana.Provider {
+    return new grafana.Provider(
+      `${this.name}-provider`,
+      {
+        cloudAccessPolicyToken: this.accessPolicyToken,
+        url: this.stack.url,
+        auth: this.serviceAccountToken,
+      },
+      { parent: this },
+    );
   }
 }

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -131,7 +131,7 @@ export class Grafana extends pulumi.ComponentResource {
       `${this.name}-access-policy`,
       {
         region: this.stack.regionSlug,
-        name: `${this.name}-access-policy`,
+        name: `ap-icb-observability-rwd-${pulumi.getStack()}`,
         scopes: [
           ...new Set([...REQUIRED_ACCESS_POLICY_SCOPES, ...(scopes ?? [])]),
         ],
@@ -149,7 +149,7 @@ export class Grafana extends pulumi.ComponentResource {
       {
         region: this.stack.regionSlug,
         accessPolicyId: this.accessPolicy.policyId,
-        namePrefix: `${this.name}-icb-access-policy-token-${pulumi.getStack()}`,
+        namePrefix: `icb-${pulumi.getStack()}`,
         expireAfter: rotation.expireAfter,
         earlyRotationWindow: rotation.earlyRotationWindow,
         deleteOnDestroy: true,
@@ -163,7 +163,7 @@ export class Grafana extends pulumi.ComponentResource {
       `${this.name}-service-account`,
       {
         stackSlug: this.stack.slug,
-        name: `${this.name}-icb-service-account-${pulumi.getStack()}`,
+        name: `sa-icb-provisioner-${pulumi.getStack()}`,
         role: 'Admin',
       },
       { parent: this },
@@ -178,7 +178,7 @@ export class Grafana extends pulumi.ComponentResource {
       {
         stackSlug: this.stack.slug,
         serviceAccountId: this.serviceAccount.id,
-        namePrefix: `${this.name}-icb-service-account-token-${pulumi.getStack()}`,
+        namePrefix: `icb-${pulumi.getStack()}`,
         secondsToLive: rotation.secondsToLive,
         earlyRotationWindowSeconds: rotation.earlyRotationWindowSeconds,
         deleteOnDestroy: true,

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -61,9 +61,9 @@ export class Grafana extends pulumi.ComponentResource {
   public readonly name: string;
   public readonly stack: pulumi.Output<grafana.cloud.GetStackResult>;
   public readonly accessPolicy: grafana.cloud.AccessPolicy;
-  public readonly accessPolicyToken: pulumi.Output<string>;
+  public readonly accessPolicyToken: grafana.cloud.AccessPolicyRotatingToken;
   public readonly serviceAccount: grafana.cloud.StackServiceAccount;
-  public readonly serviceAccountToken: pulumi.Output<string>;
+  public readonly serviceAccountToken: grafana.cloud.StackServiceAccountRotatingToken;
   public readonly provider: grafana.Provider;
   public readonly connections: GrafanaConnection[];
   public readonly folder: grafana.oss.Folder;
@@ -83,16 +83,14 @@ export class Grafana extends pulumi.ComponentResource {
     this.stack = grafana.cloud.getStackOutput({ slug: this.getStackSlug() });
 
     this.accessPolicy = this.createAccessPolicy(argsWithDefaults.scopes);
-    const accessPolicyToken = this.createAccessPolicyToken(
+    this.accessPolicyToken = this.createAccessPolicyToken(
       argsWithDefaults.accessPolicyTokenRotation,
     );
-    this.accessPolicyToken = pulumi.secret(accessPolicyToken.token);
 
     this.serviceAccount = this.createServiceAccount();
-    const serviceAccountToken = this.createServiceAccountToken(
+    this.serviceAccountToken = this.createServiceAccountToken(
       argsWithDefaults.serviceAccountTokenRotation,
     );
-    this.serviceAccountToken = pulumi.secret(serviceAccountToken.key);
 
     this.provider = this.createProvider();
 
@@ -204,9 +202,9 @@ export class Grafana extends pulumi.ComponentResource {
     return new grafana.Provider(
       `${this.name}-provider`,
       {
-        cloudAccessPolicyToken: this.accessPolicyToken,
+        cloudAccessPolicyToken: this.accessPolicyToken.token,
         url: this.stack.url,
-        auth: this.serviceAccountToken,
+        auth: this.serviceAccountToken.key,
       },
       { parent: this },
     );

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -109,11 +109,11 @@ export class Grafana extends pulumi.ComponentResource {
 
   private createAccessPolicyToken(): grafana.cloud.AccessPolicyToken {
     return new grafana.cloud.AccessPolicyToken(
-      `${this.name}-cloud-token`,
+      `${this.name}-access-policy-token`,
       {
         region: this.stack.regionSlug,
         accessPolicyId: this.accessPolicy.policyId,
-        name: `${this.name}-cloud-token`,
+        name: `${this.name}-icb-access-policy-token-${pulumi.getStack()}`,
       },
       { parent: this },
     );
@@ -121,10 +121,10 @@ export class Grafana extends pulumi.ComponentResource {
 
   private createServiceAccount(): grafana.cloud.StackServiceAccount {
     return new grafana.cloud.StackServiceAccount(
-      `${this.name}-sa`,
+      `${this.name}-service-account`,
       {
         stackSlug: this.stack.slug,
-        name: `${this.name}-sa`,
+        name: `${this.name}-icb-service-account-${pulumi.getStack()}`,
         role: 'Admin',
       },
       { parent: this },
@@ -133,11 +133,11 @@ export class Grafana extends pulumi.ComponentResource {
 
   private createServiceAccountToken(): grafana.cloud.StackServiceAccountToken {
     return new grafana.cloud.StackServiceAccountToken(
-      `${this.name}-sa-token`,
+      `${this.name}-service-account-token`,
       {
         stackSlug: this.stack.slug,
         serviceAccountId: this.serviceAccount.id,
-        name: `${this.name}-sa-token`,
+        name: `${this.name}-icb-service-account-token-${pulumi.getStack()}`,
       },
       { parent: this },
     );

--- a/tests/grafana/amp-grafana.test.ts
+++ b/tests/grafana/amp-grafana.test.ts
@@ -56,6 +56,7 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
 
   it('should have created the AMP data source', async () => {
     const grafana = ctx.outputs!.ampGrafana;
+
     const ampDataSource = (
       grafana.connections[0] as studion.grafana.AMPConnection
     ).dataSource;
@@ -63,11 +64,16 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
       typeof ampDataSource.name
     >;
 
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
+    >;
+
     await backOff(async () => {
       const { body, statusCode } = await grafanaRequest(
         ctx,
         'GET',
         `/api/datasources/name/${encodeURIComponent(ampDataSourceName)}`,
+        authToken,
       );
       assert.strictEqual(statusCode, 200, 'Expected data source to exist');
 
@@ -90,9 +96,15 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
   });
 
   it('should have created the dashboard with expected panels', async () => {
-    const dashboard = ctx.outputs!.ampGrafana.dashboards[0];
+    const grafana = ctx.outputs!.ampGrafana;
+
+    const dashboard = grafana.dashboards[0];
     const dashboardUid = dashboard.uid as unknown as Unwrap<
       typeof dashboard.uid
+    >;
+
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
     >;
 
     await backOff(async () => {
@@ -100,6 +112,7 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
         ctx,
         'GET',
         `/api/dashboards/uid/${dashboardUid}`,
+        authToken,
       );
       assert.strictEqual(statusCode, 200, 'Expected dashboard to exist');
 
@@ -135,16 +148,24 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
   it('should display metrics data in the dashboard', async () => {
     await requestEndpointWithExpectedStatus(ctx, ctx.config.usersPath, 200);
 
+    const grafana = ctx.outputs!.ampGrafana;
+
     const ampDataSource = (
-      ctx.outputs!.ampGrafana.connections[0] as studion.grafana.AMPConnection
+      grafana.connections[0] as studion.grafana.AMPConnection
     ).dataSource;
     const ampDataSourceName = ampDataSource.name as unknown as Unwrap<
       typeof ampDataSource.name
     >;
+
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
+    >;
+
     const { body: dsBody } = await grafanaRequest(
       ctx,
       'GET',
       `/api/datasources/name/${encodeURIComponent(ampDataSourceName)}`,
+      authToken,
     );
     const dsData = (await dsBody.json()) as Record<string, unknown>;
     const dataSourceUid = dsData.uid as string;
@@ -154,6 +175,7 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
         ctx,
         'POST',
         '/api/ds/query',
+        authToken,
         {
           queries: [
             {

--- a/tests/grafana/amp-grafana.test.ts
+++ b/tests/grafana/amp-grafana.test.ts
@@ -64,8 +64,8 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
       typeof ampDataSource.name
     >;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     await backOff(async () => {
@@ -103,8 +103,8 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
       typeof dashboard.uid
     >;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     await backOff(async () => {
@@ -157,8 +157,8 @@ export function testAmpGrafana(ctx: GrafanaTestContext) {
       typeof ampDataSource.name
     >;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     const { body: dsBody } = await grafanaRequest(

--- a/tests/grafana/configurable-grafana.test.ts
+++ b/tests/grafana/configurable-grafana.test.ts
@@ -8,12 +8,17 @@ import { grafanaRequest } from './util';
 
 export function testConfigurableGrafana(ctx: GrafanaTestContext) {
   it('should have created the configurable AMP data source', async () => {
+    const grafana = ctx.outputs!.configurableGrafana;
+
     const ampDataSource = (
-      ctx.outputs!.configurableGrafana
-        .connections[0] as studion.grafana.AMPConnection
+      grafana.connections[0] as studion.grafana.AMPConnection
     ).dataSource;
     const ampDataSourceName = ampDataSource.name as unknown as Unwrap<
       typeof ampDataSource.name
+    >;
+
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
     >;
 
     await backOff(async () => {
@@ -21,6 +26,7 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
         ctx,
         'GET',
         `/api/datasources/name/${encodeURIComponent(ampDataSourceName)}`,
+        authToken,
       );
       assert.strictEqual(statusCode, 200, 'Expected data source to exist');
 
@@ -43,14 +49,21 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
   });
 
   it('should have created the folder with the configured name', async () => {
-    const folder = ctx.outputs!.configurableGrafana.folder;
+    const grafana = ctx.outputs!.configurableGrafana;
+
+    const folder = grafana.folder;
     const folderUid = folder.uid as unknown as Unwrap<typeof folder.uid>;
+
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
+    >;
 
     await backOff(async () => {
       const { body, statusCode } = await grafanaRequest(
         ctx,
         'GET',
         `/api/folders/${folderUid}`,
+        authToken,
       );
       assert.strictEqual(statusCode, 200, 'Expected folder to exist');
 
@@ -64,9 +77,15 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
   });
 
   it('should have created the custom dashboard', async () => {
-    const dashboard = ctx.outputs!.configurableGrafana.dashboards[0];
+    const grafana = ctx.outputs!.configurableGrafana;
+
+    const dashboard = grafana.dashboards[0];
     const dashboardUid = dashboard.uid as unknown as Unwrap<
       typeof dashboard.uid
+    >;
+
+    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
+      typeof grafana.serviceAccountToken
     >;
 
     await backOff(async () => {
@@ -74,6 +93,7 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
         ctx,
         'GET',
         `/api/dashboards/uid/${dashboardUid}`,
+        authToken,
       );
       assert.strictEqual(statusCode, 200, 'Expected custom dashboard to exist');
 

--- a/tests/grafana/configurable-grafana.test.ts
+++ b/tests/grafana/configurable-grafana.test.ts
@@ -17,8 +17,8 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
       typeof ampDataSource.name
     >;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     await backOff(async () => {
@@ -54,8 +54,8 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
     const folder = grafana.folder;
     const folderUid = folder.uid as unknown as Unwrap<typeof folder.uid>;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     await backOff(async () => {
@@ -84,8 +84,8 @@ export function testConfigurableGrafana(ctx: GrafanaTestContext) {
       typeof dashboard.uid
     >;
 
-    const authToken = grafana.serviceAccountToken as unknown as Unwrap<
-      typeof grafana.serviceAccountToken
+    const authToken = grafana.serviceAccountToken.key as unknown as Unwrap<
+      typeof grafana.serviceAccountToken.key
     >;
 
     await backOff(async () => {

--- a/tests/grafana/index.test.ts
+++ b/tests/grafana/index.test.ts
@@ -15,6 +15,7 @@ const programArgs: InlineProgramArgs = {
 };
 
 const region = requireEnv('AWS_REGION');
+// REQUIRED SCOPES: accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write
 requireEnv('GRAFANA_CLOUD_ACCESS_POLICY_TOKEN');
 
 const ctx: GrafanaTestContext = {
@@ -24,7 +25,6 @@ const ctx: GrafanaTestContext = {
     appName: infraConfig.appName,
     ampNamespace: infraConfig.ampNamespace,
     grafanaUrl: requireEnv('GRAFANA_URL'),
-    grafanaAuth: requireEnv('GRAFANA_AUTH'),
     grafanaAwsAccountId: requireEnv('GRAFANA_AWS_ACCOUNT_ID'),
   },
   clients: {

--- a/tests/grafana/infrastructure/index.ts
+++ b/tests/grafana/infrastructure/index.ts
@@ -95,7 +95,7 @@ const configurableGrafana = new studion.grafana.GrafanaBuilder(
 )
   .withFolderName('ICB Configurable Test Folder')
   .addConnection(
-    opts =>
+    (ctx, opts) =>
       new studion.grafana.AMPConnection(
         `${appName}-cfg-amp`,
         {
@@ -104,6 +104,7 @@ const configurableGrafana = new studion.grafana.GrafanaBuilder(
           region: aws.config.requireRegion(),
           dataSourceName: configurableAmpDataSourceName,
           installPlugin: false,
+          ...ctx,
         },
         opts,
       ),

--- a/tests/grafana/test-context.ts
+++ b/tests/grafana/test-context.ts
@@ -9,7 +9,6 @@ interface Config {
   appName: string;
   ampNamespace: string;
   grafanaUrl: string;
-  grafanaAuth: string;
   grafanaAwsAccountId: string;
 }
 

--- a/tests/grafana/util.ts
+++ b/tests/grafana/util.ts
@@ -9,13 +9,14 @@ export async function grafanaRequest(
   ctx: GrafanaTestContext,
   method: Dispatcher.HttpMethod,
   path: string,
+  token: string,
   body?: unknown,
 ) {
   const url = `${ctx.config.grafanaUrl.replace(/\/$/, '')}${path}`;
   return request(url, {
     method,
     headers: {
-      Authorization: `Bearer ${ctx.config.grafanaAuth}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
This PR introduces access policy token creation with all the required scopes that are currently needed and also removes the `GRAFANA_AUTH` as a required env as it is now being created programmatically using service account resource. It also introduces a builder `addScope` method so additional scopes can be provided.

Required scope for the cloud access policy token is: 
`accesspolicies:read, accesspolicies:write, accesspolicies:delete, stacks:read, stack-service-accounts:write`