### PR TITLE
feat: respect `X-Frame-Options` from the CF S3 behavior origin

### DIFF
--- a/src/components/cloudfront/s3-cache-strategy.ts
+++ b/src/components/cloudfront/s3-cache-strategy.ts
@@ -94,7 +94,7 @@ export class S3CacheStrategy
           },
           frameOptions: {
             frameOption: 'DENY',
-            override: true,
+            override: false,
           },
           // instruct browsers to only use HTTPS
           strictTransportSecurity: {


### PR DESCRIPTION
Allow origins constructed from CloudFront S3 behaviors to control the value of `X-Frame-Options` header.