### PR TITLE
refactor: remove web server builder `Args` type

### DIFF
--- a/src/components/web-server/builder.ts
+++ b/src/components/web-server/builder.ts
@@ -7,16 +7,6 @@ import { OtelCollector } from '../../otel';
 
 export namespace WebServerBuilder {
   export type EcsConfig = Omit<WebServer.EcsConfig, 'vpc' | 'volumes'>;
-
-  export type Args = Omit<
-    WebServer.Args,
-    | 'vpc'
-    | 'cluster'
-    | 'volumes'
-    | 'domain'
-    | 'hostedZoneId'
-    | 'otelCollectorConfig'
-  >;
 }
 
 export class WebServerBuilder {
@@ -93,7 +83,7 @@ export class WebServerBuilder {
   }
 
   public withCertificate(
-    certificate: WebServerBuilder.Args['certificate'],
+    certificate: WebServer.Args['certificate'],
     hostedZoneId: pulumi.Input<string>,
     domain?: pulumi.Input<string>,
   ): this {


### PR DESCRIPTION
This introduces consistency by switching to `WebServer.Args` for all methods.