### PR TITLE
fix: rename `GrafanaBuilder.addCloudWatchLogs` to follow convention

### DIFF
--- a/src/components/grafana/builder.ts
+++ b/src/components/grafana/builder.ts
@@ -60,7 +60,7 @@ export class GrafanaBuilder {
     return this;
   }
 
-  public addCLoudWatchLogs(
+  public addCloudWatchLogs(
     name: string,
     args: Omit<CloudWatchLogsConnection.Args, 'stack'>,
   ): this {


### PR DESCRIPTION
The method name had a typo where Cloud word was incorrectly capitalized (e.g., `addCLoudWatchLogs` → `addCloudWatchLogs`), breaking consistency with other builder methods.