### PR TITLE
fix: sort out `Vpc` public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Add a minimal VPC to your Pulumi program:
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 
 export const vpcId = vpc.vpc.vpcId;
 ```
@@ -143,7 +143,7 @@ const hostedZone = aws.route53.getZoneOutput({
   privateZone: false,
 });
 
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 
 const certificate = new studion.AcmCertificate('app-cert', {
   domain: 'app.example.com',
@@ -164,7 +164,7 @@ import * as pulumi from '@pulumi/pulumi';
 import * as studion from '@studion/infra-code-blocks';
 
 const env = pulumi.getStack();
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 const cluster = new aws.ecs.Cluster('app-cluster', {});
 const logGroup = new aws.cloudwatch.LogGroup('app-otel-logs', {});
 const workspace = new aws.amp.Workspace('app-amp', {});
@@ -223,7 +223,7 @@ Use the database builder when you want the database and helper instance created 
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('platform', {});
+const vpc = new studion.Vpc('platform');
 
 const database = new studion.DatabaseBuilder('platform-db')
   .withVpc(vpc.vpc)
@@ -242,7 +242,7 @@ You can also provision `Ec2SSMConnect` directly when you want a standalone helpe
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('platform', {});
+const vpc = new studion.Vpc('platform');
 
 const ssmConnect = new studion.Ec2SSMConnect('platform-db-ssm', {
   vpc: vpc.vpc,

--- a/src/components/database/README.md
+++ b/src/components/database/README.md
@@ -11,7 +11,7 @@ Use `Database` or `DatabaseBuilder` when you want secure-by-default networking, 
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 
 const database = new studion.DatabaseBuilder('app-db')
   .withVpc(vpc.vpc)
@@ -28,7 +28,7 @@ export const passwordSecretArn = database.password.secret.arn;
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('platform', {});
+const vpc = new studion.Vpc('platform');
 
 const database = new studion.Database('platform-db', {
   vpc: vpc.vpc,

--- a/src/components/ecs-service/README.md
+++ b/src/components/ecs-service/README.md
@@ -12,7 +12,7 @@ Use it when you need ECS service plumbing—task definition, IAM roles, logging,
 import * as aws from '@pulumi/aws';
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 const cluster = new aws.ecs.Cluster('app-cluster', {});
 
 const ecsService = new studion.EcsService('worker', {
@@ -37,7 +37,7 @@ export const logGroupName = ecsService.logGroup.name;
 import * as aws from '@pulumi/aws';
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('internal', {});
+const vpc = new studion.Vpc('internal');
 const cluster = new aws.ecs.Cluster('internal-cluster', {});
 
 const taskRolePolicy: aws.types.input.iam.RoleInlinePolicy = {

--- a/src/components/redis/README.md
+++ b/src/components/redis/README.md
@@ -11,7 +11,7 @@ Use these components for caches, session stores, queues, and other low-latency s
 ```ts
 import { ElastiCacheRedis, Vpc } from '@studion/infra-code-blocks';
 
-const vpc = new Vpc('app', {});
+const vpc = new Vpc('app');
 
 const cache = new ElastiCacheRedis('app-cache', {
   vpc: vpc.vpc,

--- a/src/components/vpc/README.md
+++ b/src/components/vpc/README.md
@@ -11,7 +11,7 @@ Use it as the shared networking foundation for components such as `Database`, `E
 ```ts
 import { Vpc } from '@studion/infra-code-blocks';
 
-const vpc = new Vpc('app', {});
+const vpc = new Vpc('app');
 
 export const vpcId = vpc.vpc.vpcId;
 ```
@@ -60,15 +60,15 @@ class Vpc extends pulumi.ComponentResource {
 
 **Constructor Parameters**
 
-| Parameter                                    | Description                                 |
-| -------------------------------------------- | ------------------------------------------- |
-| `name`\*<br/>`string`                        | Logical Pulumi component name.              |
-| `args`\*<br/>`VpcArgs`                       | Direct VPC configuration object.            |
-| `opts`<br/>`pulumi.ComponentResourceOptions` | Optional Pulumi component resource options. |
+| Parameter                                    | Description                                     |
+| -------------------------------------------- | ----------------------------------------------- |
+| `name`\*<br/>`string`                        | Logical Pulumi component name.                  |
+| `args`<br/>`Vpc.Args`                        | Direct VPC configuration object. Default: `{}`. |
+| `opts`<br/>`pulumi.ComponentResourceOptions` | Optional Pulumi component resource options.     |
 
 **Configuration Options**
 
-Direct constructor input: `args: VpcArgs`
+Direct constructor input: `args: Vpc.Args`
 
 | Property                                                           | Description                                                      |
 | ------------------------------------------------------------------ | ---------------------------------------------------------------- |

--- a/src/components/vpc/index.ts
+++ b/src/components/vpc/index.ts
@@ -4,18 +4,20 @@ import { commonTags } from '../../shared/common-tags';
 import { enums } from '@pulumi/awsx/types';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
 
-export type VpcArgs = {
-  /**
-   * Number of availability zones to which the subnets defined in subnetSpecs will be deployed
-   * @default '2'
-   */
-  numberOfAvailabilityZones?: number;
-  tags?: pulumi.Input<{
-    [key: string]: pulumi.Input<string>;
-  }>;
-};
+export namespace Vpc {
+  export type Args = {
+    /**
+     * Number of availability zones to which the subnets defined in subnetSpecs will be deployed
+     * @default '2'
+     */
+    numberOfAvailabilityZones?: number;
+    tags?: pulumi.Input<{
+      [key: string]: pulumi.Input<string>;
+    }>;
+  };
+}
 
-export const defaults = {
+const defaults = {
   numberOfAvailabilityZones: 2,
 };
 
@@ -24,7 +26,7 @@ export class Vpc extends pulumi.ComponentResource {
 
   constructor(
     name: string,
-    args: VpcArgs,
+    args: Vpc.Args = {},
     opts: pulumi.ComponentResourceOptions = {},
   ) {
     super('studion:vpc:Vpc', name, {}, opts);

--- a/src/components/web-server/README.md
+++ b/src/components/web-server/README.md
@@ -12,7 +12,7 @@ Use it when a workload needs package-standard public HTTP/HTTPS ingress, load-ba
 import * as aws from '@pulumi/aws';
 import * as studion from '@studion/infra-code-blocks';
 
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 const cluster = new aws.ecs.Cluster('app-cluster', {});
 
 const webServer = new studion.WebServerBuilder('app')
@@ -43,7 +43,7 @@ const hostedZone = aws.route53.getZoneOutput({
   privateZone: false,
 });
 
-const vpc = new studion.Vpc('platform', {});
+const vpc = new studion.Vpc('platform');
 const cluster = new aws.ecs.Cluster('platform-cluster', {});
 
 const taskExecutionPolicy: aws.types.input.iam.RoleInlinePolicy = {

--- a/src/otel/README.md
+++ b/src/otel/README.md
@@ -28,7 +28,7 @@ import * as pulumi from '@pulumi/pulumi';
 import * as studion from '@studion/infra-code-blocks';
 
 const env = pulumi.getStack();
-const vpc = new studion.Vpc('app', {});
+const vpc = new studion.Vpc('app');
 const cluster = new aws.ecs.Cluster('app-cluster', {});
 const logGroup = new aws.cloudwatch.LogGroup('otel-logs', {
   retentionInDays: 7,

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -16,7 +16,7 @@ const programArgs: InlineProgramArgs = {
 
 async function provisionCommonInfra() {
   const studion = await import('@studion/infra-code-blocks');
-  const vpc = new studion.Vpc('common-infra-vpc', {});
+  const vpc = new studion.Vpc('common-infra-vpc');
   const org = pulumi.getOrganization();
 
   process.env.ICB_COMMON_INFRA_STACK_REF = `${org}/${projectName}/${stackName}`;

--- a/tests/vpc/index.test.ts
+++ b/tests/vpc/index.test.ts
@@ -13,7 +13,6 @@ import {
   SubnetState,
   VpcState,
 } from '@aws-sdk/client-ec2';
-import { defaults as vpcDefaults } from '../../src/components/vpc';
 
 const programArgs: InlineProgramArgs = {
   stackName: 'dev',
@@ -40,12 +39,7 @@ describe('Vpc component deployment', () => {
 
   it('should create a default VPC with the correct configuration', async () => {
     const defaultVpc = ctx.outputs.defaultVpc.value;
-    await testVpcConfiguration(
-      ctx,
-      defaultVpc.vpc.vpcId,
-      6,
-      vpcDefaults.numberOfAvailabilityZones,
-    );
+    await testVpcConfiguration(ctx, defaultVpc.vpc.vpcId, 6, 2);
   });
 
   it('should create a VPC with the correct configuration', async () => {
@@ -103,11 +97,7 @@ describe('Vpc component deployment', () => {
       }),
     );
     const natGateways = natGwResult.NatGateways || [];
-    assert.strictEqual(
-      natGateways.length,
-      vpcDefaults.numberOfAvailabilityZones,
-      `Should have ${vpcDefaults.numberOfAvailabilityZones} NAT gateways`,
-    );
+    assert.strictEqual(natGateways.length, 2, `Should have 2 NAT gateways`);
 
     natGateways.forEach(nat => {
       assert.strictEqual(

--- a/tests/vpc/infrastructure/index.ts
+++ b/tests/vpc/infrastructure/index.ts
@@ -8,7 +8,7 @@ const tags = {
   Environment: stackName,
 };
 
-const defaultVpc = new studion.Vpc(`${appName}-default`, {});
+const defaultVpc = new studion.Vpc(`${appName}-default`);
 
 const vpc = new studion.Vpc(`${appName}`, {
   numberOfAvailabilityZones: 3,


### PR DESCRIPTION
The `Vpc` component public API has been inconsistent with the rest of codebase.
Changes made:
- The `args` signature: `args: VpcArgs` -> `args: Vpc.Args = {}`
- The `defaults` are no longer part of the public API

Depends on: #212  