### PR TITLE
feat: support full load balancer health check configuration

### DIFF
--- a/src/components/web-server/README.md
+++ b/src/components/web-server/README.md
@@ -2,7 +2,7 @@
 
 The web-server module supplies components to expose ECS services via an internet-facing ALB, using a fluent builder interface for easy assembly.
 
-Use it when a workload needs package-standard public HTTP/HTTPS ingress, load-balancer security groups, target-group wiring, health checks, and optional TLS/Route53 custom-domain support on top of `EcsService`.
+Use it when a workload needs package-standard public HTTP/HTTPS ingress, load-balancer security groups, target-group wiring, configurable health checks, and optional TLS/Route53 custom-domain support on top of `EcsService`.
 
 ## Usage examples
 
@@ -75,6 +75,12 @@ const webServer = new studion.WebServer('platform-api', {
   domain: 'api.example.com',
   hostedZoneId: hostedZone.zoneId,
   healthCheckPath: '/readyz',
+  healthCheckConfig: {
+    healthyThreshold: 5,
+    unhealthyThreshold: 3,
+    interval: 15,
+    timeout: 3,
+  },
   loadBalancingAlgorithmType: 'round_robin',
   taskExecutionRoleInlinePolicies: [taskExecutionPolicy],
   volumes: [{ name: 'shared-data' }],
@@ -131,7 +137,8 @@ export const ecsServiceArn = webServer.service.apply(
 - Current implementation note: when `otelCollector` is provided, task-role policy fragments from the collector are combined with `taskExecutionRoleInlinePolicies` and passed to the nested `EcsService` as task-role inline policies. Review generated IAM roles when combining custom execution-role policies with OTEL.
 - The nested ECS service disables service discovery, sets `assignPublicIp: true`, and registers the main container with the load balancer target group.
 - `WebServerLoadBalancer` creates an internet-facing application load balancer in public subnets and defaults `healthCheckPath` to `'/healthcheck'`.
-- Target group health checks always use HTTP with `healthyThreshold: 3`, `unhealthyThreshold: 2`, `interval: 60`, and `timeout: 5`; only the path and load-balancing algorithm are configurable.
+- Target-group health checks use `healthCheckPath` for `healthCheck.path` and merge `healthCheckConfig` into the remaining target-group health-check settings. The component default config is `{ healthyThreshold: 3, unhealthyThreshold: 2, interval: 60, timeout: 5 }`.
+- `healthCheckConfig` is shallow-merged through the component defaults; supplying it replaces the default health-check config object, so include every non-path health-check value you want to control explicitly.
 - If a certificate is provided to `WebServerLoadBalancer`, port `80` redirects to HTTPS and a TLS listener on port `443` is created with `ELBSecurityPolicy-TLS13-1-2-2021-06`. Without a certificate, port `80` forwards directly to the target group.
 - The load balancer security group always allows inbound TCP on ports `80` and `443` from `0.0.0.0/0` and allows all outbound traffic.
 - The web-server service security group allows all protocols and ports from the load balancer security group and allows all outbound traffic.
@@ -166,34 +173,35 @@ class WebServer extends pulumi.ComponentResource {
 
 Direct constructor input: `args: WebServer.Args`
 
-| Property                                                                                                                               | Description                                                                                  |
-| -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `image`\*<br/>`pulumi.Input<string>`                                                                                                   | Main application container image.                                                            |
-| `port`\*<br/>`pulumi.Input<number>`                                                                                                    | Main application container port.                                                             |
-| `environment`<br/>`pulumi.Input<aws.ecs.KeyValuePair[]>`                                                                               | Static environment variables for the main container.                                         |
-| `secrets`<br/>`pulumi.Input<aws.ecs.Secret[]>`                                                                                         | ECS secret references for the main container.                                                |
-| `mountPoints`<br/>`EcsService.PersistentStorageMountPoint[]`                                                                           | Persistent storage mounts for the main container.                                            |
-| `cluster`\*<br/>`pulumi.Input<aws.ecs.Cluster>`                                                                                        | ECS cluster used by the nested `EcsService`.                                                 |
-| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                                                                                               | Source of public subnets for the ALB and network data for ECS.                               |
-| `volumes`<br/>`pulumi.Input<pulumi.Input<EcsService.PersistentStorageVolume>[]>`                                                       | Logical ECS volumes passed into the nested `EcsService`. Default: `[]`.                      |
-| `name`<br/>`pulumi.Input<string>`                                                                                                      | Optional ECS service name override forwarded to `EcsService`. Default: `EcsService` default. |
-| `deploymentController`<br/>`'ECS' \| 'CODE_DEPLOY' \| 'EXTERNAL'`                                                                      | Optional ECS deployment controller. Default: `EcsService` default.                           |
-| `desiredCount`<br/>`pulumi.Input<number>`                                                                                              | Desired task count for the nested ECS service. Default: `EcsService` default.                |
-| `autoscaling`<br/>`pulumi.Input<{ enabled: pulumi.Input<boolean>; minCount?: pulumi.Input<number>; maxCount?: pulumi.Input<number> }>` | ECS target-tracking autoscaling configuration. Default: `EcsService` default.                |
-| `family`<br/>`pulumi.Input<string>`                                                                                                    | Optional task definition family override. Default: `EcsService` default.                     |
-| `size`<br/>`pulumi.Input<TaskSize>`                                                                                                    | ECS CPU/memory preset or explicit size object. Default: `EcsService` default.                |
-| `logGroupNamePrefix`<br/>`pulumi.Input<string>`                                                                                        | CloudWatch log group name prefix forwarded to `EcsService`. Default: `EcsService` default.   |
-| `taskExecutionRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                      | Extra execution-role inline policies.                                                        |
-| `taskRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                               | Extra task-role inline policies.                                                             |
-| `tags`<br/>`pulumi.Input<{ [key: string]: pulumi.Input<string> }>`                                                                     | Extra tags forwarded to nested ECS resources.                                                |
-| `domain`<br/>`pulumi.Input<string>`                                                                                                    | Custom DNS name for the ALB endpoint.                                                        |
-| `certificate`<br/>`pulumi.Input<aws.acm.Certificate>`                                                                                  | Existing ACM certificate for TLS termination.                                                |
-| `hostedZoneId`<br/>`pulumi.Input<string>`                                                                                              | Required: whenever `domain` or `certificate` is provided.                                    |
-| `healthCheckPath`<br/>`pulumi.Input<string>`                                                                                           | ALB target-group health-check path. Default: `'/healthcheck'`.                               |
-| `loadBalancingAlgorithmType`<br/>`pulumi.Input<string>`                                                                                | Forwarded directly to the ALB target group. Default: AWS default.                            |
-| `initContainers`<br/>`pulumi.Input<pulumi.Input<WebServer.InitContainer>[]>`                                                           | Additional init containers. Default: `[]`.                                                   |
-| `sidecarContainers`<br/>`pulumi.Input<pulumi.Input<WebServer.SidecarContainer>[]>`                                                     | Additional sidecars. Default: `[]`.                                                          |
-| `otelCollector`<br/>`pulumi.Input<OtelCollector>`                                                                                      | Collector integration that contributes containers, volumes, and IAM policy fragments.        |
+| Property                                                                                                                               | Description                                                                                                                                                                           |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`\*<br/>`pulumi.Input<string>`                                                                                                   | Main application container image.                                                                                                                                                     |
+| `port`\*<br/>`pulumi.Input<number>`                                                                                                    | Main application container port.                                                                                                                                                      |
+| `environment`<br/>`pulumi.Input<aws.ecs.KeyValuePair[]>`                                                                               | Static environment variables for the main container.                                                                                                                                  |
+| `secrets`<br/>`pulumi.Input<aws.ecs.Secret[]>`                                                                                         | ECS secret references for the main container.                                                                                                                                         |
+| `mountPoints`<br/>`EcsService.PersistentStorageMountPoint[]`                                                                           | Persistent storage mounts for the main container.                                                                                                                                     |
+| `cluster`\*<br/>`pulumi.Input<aws.ecs.Cluster>`                                                                                        | ECS cluster used by the nested `EcsService`.                                                                                                                                          |
+| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                                                                                               | Source of public subnets for the ALB and network data for ECS.                                                                                                                        |
+| `volumes`<br/>`pulumi.Input<pulumi.Input<EcsService.PersistentStorageVolume>[]>`                                                       | Logical ECS volumes passed into the nested `EcsService`. Default: `[]`.                                                                                                               |
+| `name`<br/>`pulumi.Input<string>`                                                                                                      | Optional ECS service name override forwarded to `EcsService`. Default: `EcsService` default.                                                                                          |
+| `deploymentController`<br/>`'ECS' \| 'CODE_DEPLOY' \| 'EXTERNAL'`                                                                      | Optional ECS deployment controller. Default: `EcsService` default.                                                                                                                    |
+| `desiredCount`<br/>`pulumi.Input<number>`                                                                                              | Desired task count for the nested ECS service. Default: `EcsService` default.                                                                                                         |
+| `autoscaling`<br/>`pulumi.Input<{ enabled: pulumi.Input<boolean>; minCount?: pulumi.Input<number>; maxCount?: pulumi.Input<number> }>` | ECS target-tracking autoscaling configuration. Default: `EcsService` default.                                                                                                         |
+| `family`<br/>`pulumi.Input<string>`                                                                                                    | Optional task definition family override. Default: `EcsService` default.                                                                                                              |
+| `size`<br/>`pulumi.Input<TaskSize>`                                                                                                    | ECS CPU/memory preset or explicit size object. Default: `EcsService` default.                                                                                                         |
+| `logGroupNamePrefix`<br/>`pulumi.Input<string>`                                                                                        | CloudWatch log group name prefix forwarded to `EcsService`. Default: `EcsService` default.                                                                                            |
+| `taskExecutionRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                      | Extra execution-role inline policies.                                                                                                                                                 |
+| `taskRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                               | Extra task-role inline policies.                                                                                                                                                      |
+| `tags`<br/>`pulumi.Input<{ [key: string]: pulumi.Input<string> }>`                                                                     | Extra tags forwarded to nested ECS resources.                                                                                                                                         |
+| `domain`<br/>`pulumi.Input<string>`                                                                                                    | Custom DNS name for the ALB endpoint.                                                                                                                                                 |
+| `certificate`<br/>`pulumi.Input<aws.acm.Certificate>`                                                                                  | Existing ACM certificate for TLS termination.                                                                                                                                         |
+| `hostedZoneId`<br/>`pulumi.Input<string>`                                                                                              | Required: whenever `domain` or `certificate` is provided.                                                                                                                             |
+| `healthCheckPath`<br/>`pulumi.Input<string>`                                                                                           | ALB target-group health-check path. Default: `'/healthcheck'`.                                                                                                                        |
+| `healthCheckConfig`<br/>`Omit<aws.types.input.lb.TargetGroupHealthCheck, 'path'>`                                                      | Target-group health-check settings other than `path`; `path` is controlled by `healthCheckPath`. Default: `{ healthyThreshold: 3, unhealthyThreshold: 2, interval: 60, timeout: 5 }`. |
+| `loadBalancingAlgorithmType`<br/>`pulumi.Input<string>`                                                                                | Forwarded directly to the ALB target group. Default: AWS default.                                                                                                                     |
+| `initContainers`<br/>`pulumi.Input<pulumi.Input<WebServer.InitContainer>[]>`                                                           | Additional init containers. Default: `[]`.                                                                                                                                            |
+| `sidecarContainers`<br/>`pulumi.Input<pulumi.Input<WebServer.SidecarContainer>[]>`                                                     | Additional sidecars. Default: `[]`.                                                                                                                                                   |
+| `otelCollector`<br/>`pulumi.Input<OtelCollector>`                                                                                      | Collector integration that contributes containers, volumes, and IAM policy fragments.                                                                                                 |
 
 **Outputs**
 
@@ -287,20 +295,20 @@ class WebServerBuilder {
 
 **Builder Methods**
 
-| Method                       | Parameters                                                                                                                          | Description                                                               |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `withContainer`              | `image: WebServer.Container['image'], port: WebServer.Container['port'], config: Omit<WebServer.Container, 'image' \| 'port'> = {}` | Stores the main application container.                                    |
-| `withEcsConfig`              | `config: WebServerBuilder.EcsConfig`                                                                                                | Stores ECS cluster and service configuration.                             |
-| `withVpc`                    | `vpc: pulumi.Input<awsx.ec2.Vpc>`                                                                                                   | Stores the required VPC.                                                  |
-| `withVolume`                 | `volume: EcsService.PersistentStorageVolume`                                                                                        | Adds one logical ECS volume.                                              |
-| `withCustomDomain`           | `domain: pulumi.Input<string>, hostedZoneId: pulumi.Input<string>`                                                                  | Stores custom-domain settings and enables managed ACM flow.               |
-| `withCertificate`            | `certificate: WebServer.Args['certificate'], hostedZoneId: pulumi.Input<string>, domain?: pulumi.Input<string>`                     | Stores an existing certificate and hosted zone configuration.             |
-| `addInitContainer`           | `container: WebServer.InitContainer`                                                                                                | Adds one init container.                                                  |
-| `addSidecarContainer`        | `container: WebServer.SidecarContainer`                                                                                             | Adds one sidecar container.                                               |
-| `withOtelCollector`          | `collector: OtelCollector`                                                                                                          | Attaches collector-provided containers, volume, and IAM policy fragments. |
-| `withCustomHealthCheckPath`  | `path: WebServer.Args['healthCheckPath']`                                                                                           | Overrides the ALB health-check path.                                      |
-| `withLoadBalancingAlgorithm` | `algorithm: pulumi.Input<string>`                                                                                                   | Stores the target-group load-balancing algorithm.                         |
-| `build`                      | `opts?: pulumi.ComponentResourceOptions`                                                                                            | Validates collected state and returns a `WebServer`.                      |
+| Method                       | Parameters                                                                                                                          | Description                                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `withContainer`              | `image: WebServer.Container['image'], port: WebServer.Container['port'], config: Omit<WebServer.Container, 'image' \| 'port'> = {}` | Stores the main application container.                                            |
+| `withEcsConfig`              | `config: WebServerBuilder.EcsConfig`                                                                                                | Stores ECS cluster and service configuration.                                     |
+| `withVpc`                    | `vpc: pulumi.Input<awsx.ec2.Vpc>`                                                                                                   | Stores the required VPC.                                                          |
+| `withVolume`                 | `volume: EcsService.PersistentStorageVolume`                                                                                        | Adds one logical ECS volume.                                                      |
+| `withCustomDomain`           | `domain: pulumi.Input<string>, hostedZoneId: pulumi.Input<string>`                                                                  | Stores custom-domain settings and enables managed ACM flow.                       |
+| `withCertificate`            | `certificate: WebServer.Args['certificate'], hostedZoneId: pulumi.Input<string>, domain?: pulumi.Input<string>`                     | Stores an existing certificate and hosted zone configuration.                     |
+| `addInitContainer`           | `container: WebServer.InitContainer`                                                                                                | Adds one init container.                                                          |
+| `addSidecarContainer`        | `container: WebServer.SidecarContainer`                                                                                             | Adds one sidecar container.                                                       |
+| `withOtelCollector`          | `collector: OtelCollector`                                                                                                          | Attaches collector-provided containers, volume, and IAM policy fragments.         |
+| `withHealthCheck`            | `path: WebServer.Args['healthCheckPath'], config?: WebServer.Args['healthCheckConfig']`                                             | Stores the ALB health-check path and optional target-group health-check settings. |
+| `withLoadBalancingAlgorithm` | `algorithm: pulumi.Input<string>`                                                                                                   | Stores the target-group load-balancing algorithm.                                 |
+| `build`                      | `opts?: pulumi.ComponentResourceOptions`                                                                                            | Validates collected state and returns a `WebServer`.                              |
 
 **Build Result**
 
@@ -351,13 +359,14 @@ class WebServerLoadBalancer extends pulumi.ComponentResource {
 
 Direct constructor input: `args: WebServerLoadBalancer.Args`
 
-| Property                                                | Description                                                   |
-| ------------------------------------------------------- | ------------------------------------------------------------- |
-| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                | VPC whose public subnets host the ALB.                        |
-| `port`\*<br/>`pulumi.Input<number>`                     | Target-group port.                                            |
-| `certificate`<br/>`pulumi.Input<aws.acm.Certificate>`   | Enables a TLS listener and HTTP-to-HTTPS redirect.            |
-| `healthCheckPath`<br/>`pulumi.Input<string>`            | Target-group health-check path. Default: `'/healthcheck'`.    |
-| `loadBalancingAlgorithmType`<br/>`pulumi.Input<string>` | Forwarded directly to the target group. Default: AWS default. |
+| Property                                                                          | Description                                                                                                                                |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                                          | VPC whose public subnets host the ALB.                                                                                                     |
+| `port`\*<br/>`pulumi.Input<number>`                                               | Target-group port.                                                                                                                         |
+| `certificate`<br/>`pulumi.Input<aws.acm.Certificate>`                             | Enables a TLS listener and HTTP-to-HTTPS redirect.                                                                                         |
+| `healthCheckPath`<br/>`pulumi.Input<string>`                                      | Target-group health-check path. Default: `'/healthcheck'`.                                                                                 |
+| `healthCheckConfig`<br/>`Omit<aws.types.input.lb.TargetGroupHealthCheck, 'path'>` | Target-group health-check settings other than `path`. Default: `{ healthyThreshold: 3, unhealthyThreshold: 2, interval: 60, timeout: 5 }`. |
+| `loadBalancingAlgorithmType`<br/>`pulumi.Input<string>`                           | Forwarded directly to the target group. Default: AWS default.                                                                              |
 
 **Outputs**
 

--- a/src/components/web-server/builder.ts
+++ b/src/components/web-server/builder.ts
@@ -18,6 +18,7 @@ export class WebServerBuilder {
   private _hostedZoneId?: pulumi.Input<string>;
   private _certificate?: pulumi.Input<aws.acm.Certificate>;
   private _healthCheckPath?: pulumi.Input<string>;
+  private _healthCheckConfig?: WebServer.Args['healthCheckConfig'];
   private _loadBalancingAlgorithmType?: pulumi.Input<string>;
   private _otelCollector?: pulumi.Input<OtelCollector>;
   private _initContainers: pulumi.Input<WebServer.InitContainer>[] = [];
@@ -112,10 +113,12 @@ export class WebServerBuilder {
     return this;
   }
 
-  public withCustomHealthCheckPath(
+  public withHealthCheck(
     path: WebServer.Args['healthCheckPath'],
+    config?: WebServer.Args['healthCheckConfig'],
   ): this {
     this._healthCheckPath = path;
+    this._healthCheckConfig = config;
 
     return this;
   }
@@ -154,6 +157,7 @@ export class WebServerBuilder {
         hostedZoneId: this._hostedZoneId,
         certificate: this._certificate,
         healthCheckPath: this._healthCheckPath,
+        healthCheckConfig: this._healthCheckConfig,
         loadBalancingAlgorithmType: this._loadBalancingAlgorithmType,
         otelCollector: this._otelCollector,
         initContainers: this._initContainers,

--- a/src/components/web-server/index.ts
+++ b/src/components/web-server/index.ts
@@ -76,6 +76,10 @@ export namespace WebServer {
        * "/healthcheck"
        */
       healthCheckPath?: pulumi.Input<string>;
+      healthCheckConfig?: Omit<
+        aws.types.input.lb.TargetGroupHealthCheck,
+        'path'
+      >;
       loadBalancingAlgorithmType?: pulumi.Input<string>;
       initContainers?: pulumi.Input<pulumi.Input<WebServer.InitContainer>[]>;
       sidecarContainers?: pulumi.Input<
@@ -133,6 +137,7 @@ export class WebServer extends pulumi.ComponentResource {
         port: args.port,
         certificate: certificate ?? this.acmCertificate?.certificate,
         healthCheckPath: args.healthCheckPath,
+        healthCheckConfig: args.healthCheckConfig,
         loadBalancingAlgorithmType: args.loadBalancingAlgorithmType,
       },
       {

--- a/src/components/web-server/load-balancer.ts
+++ b/src/components/web-server/load-balancer.ts
@@ -10,6 +10,7 @@ export namespace WebServerLoadBalancer {
     port: pulumi.Input<number>;
     certificate?: pulumi.Input<aws.acm.Certificate>;
     healthCheckPath?: pulumi.Input<string>;
+    healthCheckConfig?: Omit<aws.types.input.lb.TargetGroupHealthCheck, 'path'>;
     loadBalancingAlgorithmType?: pulumi.Input<string>;
   };
 }
@@ -41,6 +42,12 @@ const webServerLoadBalancerNetworkConfig = {
 
 const defaults = {
   healthCheckPath: '/healthcheck',
+  healthCheckConfig: {
+    healthyThreshold: 3,
+    unhealthyThreshold: 2,
+    interval: 60,
+    timeout: 5,
+  },
 };
 
 export class WebServerLoadBalancer extends pulumi.ComponentResource {
@@ -61,8 +68,13 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
     this.name = name;
     const vpc = pulumi.output(args.vpc);
     const argsWithDefaults = mergeWithDefaults(defaults, args);
-    const { port, certificate, healthCheckPath, loadBalancingAlgorithmType } =
-      argsWithDefaults;
+    const {
+      port,
+      certificate,
+      healthCheckPath,
+      healthCheckConfig,
+      loadBalancingAlgorithmType,
+    } = argsWithDefaults;
 
     this.securityGroup = this.createLbSecurityGroup(vpc.vpcId);
 
@@ -84,6 +96,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
       port,
       vpc.vpcId,
       healthCheckPath,
+      healthCheckConfig,
       loadBalancingAlgorithmType,
     );
     this.httpListener = this.createLbHttpListener(
@@ -163,6 +176,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
     port: pulumi.Input<number>,
     vpcId: awsx.ec2.Vpc['vpcId'],
     healthCheckPath: pulumi.Input<string>,
+    healthCheckConfig: WebServerLoadBalancer.Args['healthCheckConfig'],
     loadBalancingAlgorithmType?: pulumi.Input<string>,
   ): aws.lb.TargetGroup {
     return new aws.lb.TargetGroup(
@@ -175,10 +189,7 @@ export class WebServerLoadBalancer extends pulumi.ComponentResource {
         vpcId,
         loadBalancingAlgorithmType,
         healthCheck: {
-          healthyThreshold: 3,
-          unhealthyThreshold: 2,
-          interval: 60,
-          timeout: 5,
+          ...healthCheckConfig,
           path: healthCheckPath,
         },
         tags: { ...commonTags, Name: `${this.name}-target-group` },

--- a/tests/build/index.tst.ts
+++ b/tests/build/index.tst.ts
@@ -91,8 +91,8 @@ describe('Build output', () => {
         );
       });
 
-      it('should have withCustomHealthCheckPath method', () => {
-        expect(builder.withCustomHealthCheckPath).type.toBeCallableWith(
+      it('should have withHealthCheck method', () => {
+        expect(builder.withHealthCheck).type.toBeCallableWith(
           '/custom/healthCheck/path',
         );
       });

--- a/tests/web-server/index.test.ts
+++ b/tests/web-server/index.test.ts
@@ -131,6 +131,16 @@ describe('Web server component deployment', () => {
       ctx.config.healthCheckPath,
       'Target group should have correct health check path',
     );
+    assert.deepStrictEqual(
+      {
+        healthyThreshold: tg.HealthyThresholdCount,
+        unhealthyThreshold: tg.UnhealthyThresholdCount,
+        interval: tg.HealthCheckIntervalSeconds,
+        timeout: tg.HealthCheckTimeoutSeconds,
+      },
+      ctx.config.healthCheckConfig,
+      'Target group should have correct health check configuration',
+    );
 
     const attributesCommand = new DescribeTargetGroupAttributesCommand({
       TargetGroupArn: webServer.lb.targetGroup.arn,

--- a/tests/web-server/infrastructure/config.ts
+++ b/tests/web-server/infrastructure/config.ts
@@ -1,8 +1,17 @@
 export const webServerName = 'web-server-test';
-export const healthCheckPath = '/healthcheck';
 
 export const webServerImageName = 'nginxdemos/nginx-hello:plain-text';
+
 export const webServerPort = 8080;
+
+export const healthCheckPath = '/healthcheck';
+
+export const healthCheckConfig = {
+  healthyThreshold: 5,
+  unhealthyThreshold: 3,
+  interval: 15,
+  timeout: 3,
+};
 
 const baseDomain = `ws.${process.env.ICB_DOMAIN_NAME!}`;
 

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -5,6 +5,7 @@ import * as util from '../../util';
 import {
   webServerName,
   healthCheckPath,
+  healthCheckConfig,
   webServerWithDomainConfig,
   webServerWithSanCertificateConfig,
   webServerWithCertificateConfig,
@@ -68,7 +69,7 @@ const webServer = new studion.WebServerBuilder(webServerName)
   .addSidecarContainer(sidecar)
   .withVpc(vpc.vpc)
   .withOtelCollector(otelCollector)
-  .withCustomHealthCheckPath(healthCheckPath)
+  .withHealthCheck(healthCheckPath, healthCheckConfig)
   .withLoadBalancingAlgorithm('least_outstanding_requests')
   .build({ parent: cluster });
 
@@ -81,7 +82,7 @@ const webServerWithDomain = new studion.WebServerBuilder(`web-server-domain`)
   .withContainer(webServerImageName, 8080)
   .withEcsConfig(ecs)
   .withVpc(vpc.vpc)
-  .withCustomHealthCheckPath(healthCheckPath)
+  .withHealthCheck(healthCheckPath)
   .withCustomDomain(webServerWithDomainConfig.primary, hostedZone.zoneId)
   .build({ parent: cluster });
 
@@ -100,7 +101,7 @@ const webServerWithSanCertificate = new studion.WebServerBuilder(
   .withContainer(webServerImageName, 8080)
   .withEcsConfig(ecs)
   .withVpc(vpc.vpc)
-  .withCustomHealthCheckPath(healthCheckPath)
+  .withHealthCheck(healthCheckPath)
   .withCertificate(sanWebServerCert.certificate, hostedZone.zoneId)
   .build({
     parent: cluster,
@@ -120,7 +121,7 @@ const webServerWithCertificate = new studion.WebServerBuilder(`web-server-cert`)
   .withContainer(webServerImageName, 8080)
   .withEcsConfig(ecs)
   .withVpc(vpc.vpc)
-  .withCustomHealthCheckPath(healthCheckPath)
+  .withHealthCheck(healthCheckPath)
   .withCertificate(
     certWebServer.certificate,
     hostedZone.zoneId,

--- a/tests/web-server/test-context.ts
+++ b/tests/web-server/test-context.ts
@@ -8,6 +8,12 @@ import { Route53Client } from '@aws-sdk/client-route-53';
 interface WebServerTestConfig {
   webServerName: string;
   healthCheckPath: string;
+  healthCheckConfig: {
+    healthyThreshold: number;
+    unhealthyThreshold: number;
+    interval: number;
+    timeout: number;
+  };
   webServerImageName: string;
   webServerPort: number;
   webServerWithDomainConfig: {
@@ -42,6 +48,4 @@ interface AwsContext {
 }
 
 export interface WebServerTestContext
-  extends ConfigContext,
-    PulumiProgramContext,
-    AwsContext {}
+  extends ConfigContext, PulumiProgramContext, AwsContext {}


### PR DESCRIPTION
Add support for fully configuring the load balancer target group health check through the `healthCheckConfig` argument, instead of only allowing a custom health check path.

Rename the builder method `withCustomHealthCheckPath` -> `withHealthCheck` to reflect the broader configuration support.

Depends on: #212 