### PR TITLE
fix: otel collector mount target race condition

### DIFF
--- a/src/components/ecs-service/index.ts
+++ b/src/components/ecs-service/index.ts
@@ -9,13 +9,17 @@ import { TaskSize, parseTaskSize } from './task-size';
 const config = new pulumi.Config('aws');
 const awsRegion = config.require('region');
 
-type PersistentStorage = {
-  fileSystem: aws.efs.FileSystem;
-  accessPoint: aws.efs.AccessPoint;
-  mountTargets: pulumi.Output<aws.efs.MountTarget[]>;
-};
-
 export namespace EcsService {
+  /**
+   * Represents the EFS-backed persistent storage attached to an ECS service.
+   * Created automatically when `volumes` are configured.
+   */
+  export type PersistentStorage = {
+    fileSystem: aws.efs.FileSystem;
+    accessPoint: aws.efs.AccessPoint;
+    mountTargets: pulumi.Output<aws.efs.MountTarget[]>;
+  };
+
   /**
    * Create a named volume that can be mounted into one or more containers.
    * Used with Amazon EFS to enable persistent storage across:
@@ -202,7 +206,7 @@ export class EcsService extends pulumi.ComponentResource {
   service: aws.ecs.Service;
   securityGroups: pulumi.Output<aws.ec2.SecurityGroup>[];
   serviceDiscoveryService?: aws.servicediscovery.Service;
-  persistentStorage: pulumi.Output<PersistentStorage | undefined>;
+  persistentStorage: pulumi.Output<EcsService.PersistentStorage | undefined>;
 
   constructor(
     name: string,
@@ -239,7 +243,7 @@ export class EcsService extends pulumi.ComponentResource {
       .output(argsWithDefaults.volumes)
       .apply(volumes => {
         if (!volumes.length) return undefined;
-        return this.createPersistentStorage(this.vpc);
+        return this.createPersistentStorage(this.vpc); // TODO: ternary
       });
 
     this.taskDefinition = this.createTaskDefinition(
@@ -634,7 +638,7 @@ export class EcsService extends pulumi.ComponentResource {
 
   private createPersistentStorage(
     vpc: pulumi.Output<awsx.ec2.Vpc>,
-  ): PersistentStorage {
+  ): EcsService.PersistentStorage {
     const efs = new aws.efs.FileSystem(
       `${this.name}-efs`,
       {

--- a/src/components/ecs-service/index.ts
+++ b/src/components/ecs-service/index.ts
@@ -12,6 +12,7 @@ const awsRegion = config.require('region');
 type PersistentStorage = {
   fileSystem: aws.efs.FileSystem;
   accessPoint: aws.efs.AccessPoint;
+  mountTargets: pulumi.Output<aws.efs.MountTarget[]>;
 };
 
 export namespace EcsService {
@@ -201,7 +202,7 @@ export class EcsService extends pulumi.ComponentResource {
   service: aws.ecs.Service;
   securityGroups: pulumi.Output<aws.ec2.SecurityGroup>[];
   serviceDiscoveryService?: aws.servicediscovery.Service;
-  persistentStorage?: PersistentStorage;
+  persistentStorage: pulumi.Output<PersistentStorage | undefined>;
 
   constructor(
     name: string,
@@ -234,11 +235,12 @@ export class EcsService extends pulumi.ComponentResource {
     );
     this.taskRole = this.createTaskRole(taskRoleInlinePolicies);
 
-    pulumi.output(argsWithDefaults.volumes).apply(volume => {
-      if (volume.length) {
-        this.persistentStorage = this.createPersistentStorage(this.vpc);
-      }
-    });
+    this.persistentStorage = pulumi
+      .output(argsWithDefaults.volumes)
+      .apply(volumes => {
+        if (!volumes.length) return undefined;
+        return this.createPersistentStorage(this.vpc);
+      });
 
     this.taskDefinition = this.createTaskDefinition(
       argsWithDefaults.containers,
@@ -333,21 +335,23 @@ export class EcsService extends pulumi.ComponentResource {
   private createTaskDefinitionVolumes(
     volumes: pulumi.Output<EcsService.PersistentStorageVolume[]>,
   ) {
-    return volumes.apply(volumes => {
-      if (!volumes.length || !this.persistentStorage) return;
+    return pulumi
+      .all([volumes, this.persistentStorage])
+      .apply(([volumes, storage]) => {
+        if (!volumes.length || !storage) return;
 
-      return volumes.map(volume => ({
-        name: pulumi.output(volume).name,
-        efsVolumeConfiguration: {
-          fileSystemId: this.persistentStorage!.fileSystem.id,
-          transitEncryption: 'ENABLED',
-          authorizationConfig: {
-            accessPointId: this.persistentStorage!.accessPoint.id,
-            iam: 'ENABLED',
+        return volumes.map(volume => ({
+          name: pulumi.output(volume).name,
+          efsVolumeConfiguration: {
+            fileSystemId: storage.fileSystem.id,
+            transitEncryption: 'ENABLED',
+            authorizationConfig: {
+              accessPointId: storage.accessPoint.id,
+              iam: 'ENABLED',
+            },
           },
-        },
-      }));
-    });
+        }));
+      });
   }
 
   private createContainerDefinition(container: EcsService.Container) {
@@ -510,6 +514,10 @@ export class EcsService extends pulumi.ComponentResource {
         .apply(groups => groups.map(it => it.id)),
     };
 
+    const dependsOn = this.persistentStorage.apply(
+      s => s?.mountTargets ?? pulumi.output([]),
+    );
+
     return new aws.ecs.Service(
       `${this.name}-service`,
       {
@@ -531,7 +539,7 @@ export class EcsService extends pulumi.ComponentResource {
         }),
         tags: { ...commonTags, ...ecsServiceArgs.tags },
       },
-      { parent: this },
+      { parent: this, dependsOn },
     );
   }
 
@@ -666,19 +674,20 @@ export class EcsService extends pulumi.ComponentResource {
       { parent: this },
     );
 
-    this.vpc.privateSubnetIds.apply(subnetIds => {
-      subnetIds.forEach(subnetId => {
-        const mountTarget = new aws.efs.MountTarget(
-          `${this.name}-mount-target-${subnetId}`,
-          {
-            fileSystemId: efs.id,
-            subnetId,
-            securityGroups: [securityGroup.id],
-          },
-          { parent: this },
-        );
-      });
-    });
+    const mountTargets = this.vpc.privateSubnetIds.apply(subnetIds =>
+      subnetIds.map(
+        subnetId =>
+          new aws.efs.MountTarget(
+            `${this.name}-mount-target-${subnetId}`,
+            {
+              fileSystemId: efs.id,
+              subnetId,
+              securityGroups: [securityGroup.id],
+            },
+            { parent: this },
+          ),
+      ),
+    );
 
     const accessPoint = new aws.efs.AccessPoint(
       `${this.name}-efs-ap`,
@@ -700,6 +709,6 @@ export class EcsService extends pulumi.ComponentResource {
       { parent: this },
     );
 
-    return { fileSystem: efs, accessPoint };
+    return { fileSystem: efs, accessPoint, mountTargets };
   }
 }

--- a/src/components/ecs-service/index.ts
+++ b/src/components/ecs-service/index.ts
@@ -241,10 +241,9 @@ export class EcsService extends pulumi.ComponentResource {
 
     this.persistentStorage = pulumi
       .output(argsWithDefaults.volumes)
-      .apply(volumes => {
-        if (!volumes.length) return undefined;
-        return this.createPersistentStorage(this.vpc); // TODO: ternary
-      });
+      .apply(volumes =>
+        volumes.length ? this.createPersistentStorage(this.vpc) : undefined,
+      );
 
     this.taskDefinition = this.createTaskDefinition(
       argsWithDefaults.containers,


### PR DESCRIPTION
This PR fixes the issue where we have tasks failing to mount EFS volumes because mount targets were not created at the exact moment.