### PR TITLE
refactor: group web server load balancer arguments

### DIFF
--- a/src/components/web-server/README.md
+++ b/src/components/web-server/README.md
@@ -232,7 +232,7 @@ type Container = Pick<
 };
 ```
 
-Used to define the main application container before ECS-specific transformation. Combined with the other types to create `WebServer.Args` intersection type.
+Used to define the main application container before ECS-specific transformation. Combined with `WebServer.EcsConfig`, `WebServer.LoadBalancerConfig`, and WebServer-specific fields to create the `WebServer.Args` intersection type.
 
 **`WebServer.EcsConfig`**
 
@@ -255,7 +255,18 @@ type EcsConfig = Pick<
 >;
 ```
 
-Forwarded into the nested `EcsService` after the web-server-specific ALB wiring is added. Combined with the other types to create `WebServer.Args` intersection type.
+Forwarded into the nested `EcsService` after the web-server-specific ALB wiring is added. Combined with `WebServer.Container`, `WebServer.LoadBalancerConfig`, and WebServer-specific fields to create the `WebServer.Args` intersection type.
+
+**`WebServer.LoadBalancerConfig`**
+
+```ts
+type LoadBalancerConfig = Pick<
+  WebServerLoadBalancer.Args,
+  'healthCheckPath' | 'healthCheckConfig' | 'loadBalancingAlgorithmType'
+>;
+```
+
+Used to group the load-balancer-specific options that `WebServer` forwards into the nested `WebServerLoadBalancer`. Combined with `WebServer.Container`, `WebServer.EcsConfig`, and WebServer-specific fields to create the `WebServer.Args` intersection type.
 
 **`WebServer.InitContainer`**
 
@@ -306,8 +317,8 @@ class WebServerBuilder {
 | `addInitContainer`           | `container: WebServer.InitContainer`                                                                                                | Adds one init container.                                                          |
 | `addSidecarContainer`        | `container: WebServer.SidecarContainer`                                                                                             | Adds one sidecar container.                                                       |
 | `withOtelCollector`          | `collector: OtelCollector`                                                                                                          | Attaches collector-provided containers, volume, and IAM policy fragments.         |
-| `withHealthCheck`            | `path: WebServer.Args['healthCheckPath'], config?: WebServer.Args['healthCheckConfig']`                                             | Stores the ALB health-check path and optional target-group health-check settings. |
-| `withLoadBalancingAlgorithm` | `algorithm: pulumi.Input<string>`                                                                                                   | Stores the target-group load-balancing algorithm.                                 |
+| `withHealthCheck`            | `path: WebServer.LoadBalancerConfig['healthCheckPath'], config?: WebServer.LoadBalancerConfig['healthCheckConfig']`                 | Stores the ALB health-check path and optional target-group health-check settings. |
+| `withLoadBalancingAlgorithm` | `algorithm: WebServer.LoadBalancerConfig['loadBalancingAlgorithmType']`                                                             | Stores the target-group load-balancing algorithm.                                 |
 | `build`                      | `opts?: pulumi.ComponentResourceOptions`                                                                                            | Validates collected state and returns a `WebServer`.                              |
 
 **Build Result**

--- a/src/components/web-server/builder.ts
+++ b/src/components/web-server/builder.ts
@@ -114,8 +114,8 @@ export class WebServerBuilder {
   }
 
   public withHealthCheck(
-    path: WebServer.Args['healthCheckPath'],
-    config?: WebServer.Args['healthCheckConfig'],
+    path: WebServer.LoadBalancerConfig['healthCheckPath'],
+    config?: WebServer.LoadBalancerConfig['healthCheckConfig'],
   ): this {
     this._healthCheckPath = path;
     this._healthCheckConfig = config;
@@ -123,7 +123,9 @@ export class WebServerBuilder {
     return this;
   }
 
-  public withLoadBalancingAlgorithm(algorithm: pulumi.Input<string>) {
+  public withLoadBalancingAlgorithm(
+    algorithm: WebServer.LoadBalancerConfig['loadBalancingAlgorithmType'],
+  ) {
     this._loadBalancingAlgorithmType = algorithm;
 
     return this;

--- a/src/components/web-server/index.ts
+++ b/src/components/web-server/index.ts
@@ -32,6 +32,11 @@ export namespace WebServer {
     | 'tags'
   >;
 
+  export type LoadBalancerConfig = Pick<
+    WebServerLoadBalancer.Args,
+    'healthCheckPath' | 'healthCheckConfig' | 'loadBalancingAlgorithmType'
+  >;
+
   export type InitContainer = Omit<EcsService.Container, 'essential'>;
   export type SidecarContainer = Omit<
     EcsService.Container,
@@ -40,28 +45,29 @@ export namespace WebServer {
     Required<Pick<EcsService.Container, 'healthCheck'>>;
 
   export type Args = EcsConfig &
-    Container & {
+    Container &
+    LoadBalancerConfig & {
       /**
-       * Domain name for CloudFront distribution. Implies creation of certificate
+       * Domain name for the ALB endpoint. Implies creation of certificate
        * and alias record. Must belong to the provided hosted zone.
        * Providing the `certificate` argument has following effects:
        * - Certificate creation is skipped
        * - Provided certificate must cover the domain name
        * Responsibility to ensure mentioned requirements in on the consumer, and
-       * falling to do so will result in unexpected behavior.
+       * failing to do so will result in unexpected behavior.
        */
       domain?: pulumi.Input<string>;
       /**
-       * Certificate for CloudFront distribution. Domain and alternative domains
+       * Certificate for the ALB HTTPS listener. Domain and alternative domains
        * are automatically pulled from the certificate and translated into alias
        * records. Domains covered by the certificate, must belong to the provided
-       * hosted zone. The certificate must be in `us-east-1` region. In a case
-       * of wildcard certificate the `domain` argument is required.
+       * hosted zone. In a case of wildcard certificate the `domain` argument
+       * is required.
        * Providing the `domain` argument has following effects:
        * - Alias records creation, from automatically pulled domains, is skipped
        * - Certificate must cover the provided domain name
        * Responsibility to ensure mentioned requirements in on the consumer, and
-       * falling to do so will result in unexpected behavior.
+       * failing to do so will result in unexpected behavior.
        */
       certificate?: pulumi.Input<aws.acm.Certificate>;
       /**
@@ -69,18 +75,6 @@ export namespace WebServer {
        * arguments are provided.
        */
       hostedZoneId?: pulumi.Input<string>;
-      /**
-       * Path for the load balancer target group health check request.
-       *
-       * @default
-       * "/healthcheck"
-       */
-      healthCheckPath?: pulumi.Input<string>;
-      healthCheckConfig?: Omit<
-        aws.types.input.lb.TargetGroupHealthCheck,
-        'path'
-      >;
-      loadBalancingAlgorithmType?: pulumi.Input<string>;
       initContainers?: pulumi.Input<pulumi.Input<WebServer.InitContainer>[]>;
       sidecarContainers?: pulumi.Input<
         pulumi.Input<WebServer.SidecarContainer>[]


### PR DESCRIPTION
Use `WebServer.LoadBalancerConfig` to reference the arguments from web server load balancer and keep the single source of truth.

Update `WebServerBuilder` method signatures to reference the new load balancer config type, and correct WebServer domain/certificate documentation to describe ALB behavior instead of CloudFront behavior.