### PR TITLE
fix: call `registerOutputs` for static site components

### DIFF
--- a/src/components/static-site/index.ts
+++ b/src/components/static-site/index.ts
@@ -101,6 +101,8 @@ export class StaticSite extends pulumi.ComponentResource {
       },
       { parent: this },
     );
+
+    this.registerOutputs();
   }
 
   private getCloudFrontBehaviors(

--- a/src/components/static-site/s3-assets.ts
+++ b/src/components/static-site/s3-assets.ts
@@ -42,6 +42,8 @@ export class S3Assets extends pulumi.ComponentResource {
 
     this.bucket = bucket;
     this.websiteConfig = websiteConfig;
+
+    this.registerOutputs();
   }
 
   private setupWebsiteBucketAccess(bucket: aws.s3.Bucket): void {


### PR DESCRIPTION
The `StaticSite` as `S3Asset` components now call the `registerOutputs` at the end of constructor to send completion signal as early as possible and to be consistent with the rest of the code base.