### PR TITLE
build: update `tmp` to `0.2.7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8504,9 +8504,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   "overrides": {
     "basic-ftp": ">5.3.0",
     "fast-xml-builder": ">=1.2.0",
-    "protobufjs": ">7.5.5"
+    "protobufjs": ">7.5.5",
+    "tmp": ">0.2.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
To resolve high severity vulnerability explicitly override versions of `tmp`.