### PR TITLE
feat: drop `pulumi.Config` in favor of explicit args

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The package provides building blocks across four areas:
 
 - Pulumi CLI authenticated with `pulumi login`.
 - AWS credentials with permissions for the resources you create.
-- Pulumi AWS provider region configuration, for example `pulumi config set aws:region eu-central-1` (environment: `AWS_REGION`).
+- Pulumi AWS provider region configuration, for example `pulumi config set aws:region eu-central-1` (environment: `AWS_REGION`). Region-aware components use an explicit component `region` when provided and otherwise derive the region from the active AWS provider.
 
 **Required only for ECS/web-service components**
 
@@ -213,7 +213,7 @@ This workflow reuses the helper EC2 instance plus the SSM, EC2 Messages, and SSM
 ### Prerequisites
 
 1. Install the AWS CLI and the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html).
-2. Ensure your stack sets `aws:region`, because `Ec2SSMConnect` uses region-specific VPC endpoint service names.
+2. Ensure an AWS region is available. `Ec2SSMConnect` uses explicit `region` when provided and otherwise derives the region from the active AWS provider for region-specific VPC endpoint service names.
 3. Provision a `Database` with SSM helper access enabled.
 
 ### Enable SSM access
@@ -344,7 +344,7 @@ Contributions should keep the documentation and exported API aligned.
 
 ## Troubleshooting
 
-- **Missing AWS region or provider-region error:** run `pulumi config set aws:region <region>` or set `AWS_REGION`. ECS service and SSM Connect components require the region explicitly.
+- **Missing AWS region or provider-region error:** configure the AWS provider region, for example with `pulumi config set aws:region <region>` or `AWS_REGION`, or pass an explicit component `region` where supported.
 - **AWS credentials, profile, or authorization errors:** configure AWS credentials, set the intended `AWS_PROFILE`, and confirm the identity has the required permissions.
 - **Route 53 validation or custom-domain setup failure:** confirm that the domain is managed by, or delegated to, the hosted zone whose ID you passed to the component.
 - **ACM certificate validation appears stuck:** DNS validation can take time. Check that the generated Route 53 validation record exists in the public hosted zone.

--- a/src/components/database/README.md
+++ b/src/components/database/README.md
@@ -68,7 +68,7 @@ export const ssmHostId = ssmConnect.ec2.id;
 - The primary RDS resource always receives a generated `finalSnapshotIdentifier` of `${name}-final-snapshot-${stack}`; AWS uses it only when `skipFinalSnapshot` is false.
 - Replica instances are always created with `storageEncrypted: true`, `publiclyAccessible: false`, `skipFinalSnapshot: true`, and the same maintenance window as the primary.
 - Enhanced monitoring and Performance Insights are enabled only when a monitoring role is available; the primary creates that role only when `enableMonitoring` is truthy.
-- `Ec2SSMConnect` requires Pulumi config `aws:region` because the VPC endpoint service names are region-specific.
+- `Ec2SSMConnect` uses an explicit `region` when provided and otherwise derives the region from the active AWS provider for region-specific VPC endpoint service names.
 - `Ec2SSMConnect` always places the helper instance and all three interface endpoints in the first private subnet only, and the helper instance does not receive a public IP.
 - The helper security group is attached to the EC2 instance and interface endpoints, allows TCP/22 and TCP/443 from the VPC CIDR, and allows all outbound traffic; database access relies on the database security group allowing TCP/5432 from the VPC CIDR.
 - When `ami` is omitted, `Ec2SSMConnect` looks up the most recent Amazon Linux 2023 ARM64 EBS HVM AMI with ENA support and defaults the instance type to `t4g.nano`.
@@ -208,9 +208,9 @@ type ReplicaConfig = Partial<
 type SSMConnectConfig = Omit<Ec2SSMConnect.Args, 'vpc'>;
 ```
 
-| Difference from `Ec2SSMConnect.Args` | Description                                                           |
-| ------------------------------------ | --------------------------------------------------------------------- |
-| Omits `vpc`                          | `Database` always passes its own `vpc` to the nested `Ec2SSMConnect`. |
+| Difference from `Ec2SSMConnect.Args` | Description                                                                                                       |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Omits `vpc`                          | `Database` always passes its own `vpc` to the nested `Ec2SSMConnect`; options such as `region` pass through here. |
 
 ### `DatabaseBuilder`
 
@@ -374,12 +374,13 @@ class Ec2SSMConnect extends pulumi.ComponentResource {
 
 Direct constructor input: `args: Ec2SSMConnect.Args`
 
-| Property                                                        | Description                                                                                                                                         |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                        | Source of private subnets and VPC ID.                                                                                                               |
-| `ami`<br/>`pulumi.Input<string>`                                | If omitted, the component looks up the most recent AL2023 ARM64 EBS HVM AMI with ENA support. Default: latest matching Amazon Linux 2023 ARM64 AMI. |
-| `instanceType`<br/>`pulumi.Input<string>`                       | Helper EC2 instance type. Default: `'t4g.nano'`.                                                                                                    |
-| `tags`<br/>`pulumi.Input<Record<string, pulumi.Input<string>>>` | Extra tags merged into the instance `Name` tag and package common tags.                                                                             |
+| Property                                                        | Description                                                                                                                                                                            |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                        | Source of private subnets and VPC ID.                                                                                                                                                  |
+| `ami`<br/>`pulumi.Input<string>`                                | If omitted, the component looks up the most recent AL2023 ARM64 EBS HVM AMI with ENA support. Default: latest matching Amazon Linux 2023 ARM64 AMI.                                    |
+| `instanceType`<br/>`pulumi.Input<string>`                       | Helper EC2 instance type. Default: `'t4g.nano'`.                                                                                                                                       |
+| `region`<br/>`pulumi.Input<string>`                             | AWS region used for SSM, EC2 Messages, and SSM Messages VPC endpoint service names. Uses this explicit value when provided; otherwise derives the region from the active AWS provider. |
+| `tags`<br/>`pulumi.Input<Record<string, pulumi.Input<string>>>` | Extra tags merged into the instance `Name` tag and package common tags.                                                                                                                |
 
 **Outputs**
 

--- a/src/components/database/ec2-ssm-connect.ts
+++ b/src/components/database/ec2-ssm-connect.ts
@@ -3,15 +3,14 @@ import * as awsx from '@pulumi/awsx';
 import * as pulumi from '@pulumi/pulumi';
 import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
-
-const config = new pulumi.Config('aws');
-const awsRegion = config.require('region');
+import { resolveAwsRegion } from '../../shared/resolve-aws-region';
 
 export namespace Ec2SSMConnect {
   export type Args = {
     vpc: pulumi.Input<awsx.ec2.Vpc>;
     ami?: pulumi.Input<string>;
     instanceType?: pulumi.Input<string>;
+    region?: pulumi.Input<string>;
     tags?: pulumi.Input<{
       [key: string]: pulumi.Input<string>;
     }>;
@@ -56,6 +55,7 @@ export class Ec2SSMConnect extends pulumi.ComponentResource {
     this.name = name;
 
     const vpcOutput = pulumi.output(vpc);
+    const region = resolveAwsRegion(args, this);
     const subnetId = vpcOutput.privateSubnetIds.apply(ids => ids[0]);
     const amiId =
       ami ??
@@ -159,7 +159,7 @@ export class Ec2SSMConnect extends pulumi.ComponentResource {
       {
         vpcId: vpcOutput.vpcId,
         ipAddressType: 'ipv4',
-        serviceName: `com.amazonaws.${awsRegion}.ssm`,
+        serviceName: pulumi.interpolate`com.amazonaws.${region}.ssm`,
         vpcEndpointType: 'Interface',
         subnetIds: [subnetId],
         securityGroupIds: [this.ec2SecurityGroup.id],
@@ -174,7 +174,7 @@ export class Ec2SSMConnect extends pulumi.ComponentResource {
       {
         vpcId: vpcOutput.vpcId,
         ipAddressType: 'ipv4',
-        serviceName: `com.amazonaws.${awsRegion}.ec2messages`,
+        serviceName: pulumi.interpolate`com.amazonaws.${region}.ec2messages`,
         vpcEndpointType: 'Interface',
         subnetIds: [subnetId],
         securityGroupIds: [this.ec2SecurityGroup.id],
@@ -189,7 +189,7 @@ export class Ec2SSMConnect extends pulumi.ComponentResource {
       {
         vpcId: vpcOutput.vpcId,
         ipAddressType: 'ipv4',
-        serviceName: `com.amazonaws.${awsRegion}.ssmmessages`,
+        serviceName: pulumi.interpolate`com.amazonaws.${region}.ssmmessages`,
         vpcEndpointType: 'Interface',
         subnetIds: [subnetId],
         securityGroupIds: [this.ec2SecurityGroup.id],

--- a/src/components/ecs-service/README.md
+++ b/src/components/ecs-service/README.md
@@ -99,7 +99,7 @@ export const persistentMountTargetIds = ecsService.persistentStorage.apply(
 
 ## Implementation notes
 
-- The component requires Pulumi config `aws:region` because every container definition receives an `awslogs` log configuration with `awslogs-region` set from that value.
+- The component uses an explicit `region` when provided and otherwise derives the region from the active AWS provider for each container definition's `awslogs-region` setting.
 - The CloudWatch log group always uses `retentionInDays: 14` and defaults `namePrefix` to `/ecs/${name}-` unless `logGroupNamePrefix` is provided.
 - The service always uses `launchType: 'FARGATE'` and `enableExecuteCommand: true`.
 - The task definition always uses `networkMode: 'awsvpc'` and `requiresCompatibilities: ['FARGATE']`.
@@ -146,26 +146,27 @@ class EcsService extends pulumi.ComponentResource {
 
 Direct constructor input: `args: EcsService.Args`
 
-| Property                                                                                                                               | Description                                                                                                  |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `cluster`\*<br/>`pulumi.Input<aws.ecs.Cluster>`                                                                                        | ECS cluster that will run the service.                                                                       |
-| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                                                                                               | Provides subnets, VPC ID, and CIDR-based security group rules.                                               |
-| `containers`\*<br/>`EcsService.Container[]`                                                                                            | Full task container list.                                                                                    |
-| `loadBalancers`<br/>`pulumi.Input<EcsService.LoadBalancerConfig[]>`                                                                    | Optional ECS service-to-target-group registrations.                                                          |
-| `volumes`<br/>`pulumi.Input<pulumi.Input<EcsService.PersistentStorageVolume>[]>`                                                       | Any non-empty value triggers creation of shared EFS-backed persistent storage. Default: `[]`.                |
-| `name`<br/>`pulumi.Input<string>`                                                                                                      | ECS service name override. Default: component name.                                                          |
-| `deploymentController`<br/>`'ECS' \| 'CODE_DEPLOY' \| 'EXTERNAL'`                                                                      | ECS deployment controller type. Default: `'ECS'`.                                                            |
-| `desiredCount`<br/>`pulumi.Input<number>`                                                                                              | Initial desired task count. Default: `1`.                                                                    |
-| `family`<br/>`pulumi.Input<string>`                                                                                                    | Task definition family. Default: `<name>-task-definition-<stack>`.                                           |
-| `size`<br/>`pulumi.Input<TaskSize>`                                                                                                    | CPU/memory preset or explicit `{ cpu, memory }` object. Default: `'small'`.                                  |
-| `logGroupNamePrefix`<br/>`pulumi.Input<string>`                                                                                        | Passed to `aws.cloudwatch.LogGroup.namePrefix`. Default: `/ecs/<name>-`.                                     |
-| `securityGroup`<br/>`pulumi.Input<aws.ec2.SecurityGroup>`                                                                              | If omitted, the component creates a VPC-wide internal service security group. Default: generated default SG. |
-| `assignPublicIp`<br/>`pulumi.Input<boolean>`                                                                                           | Selects public subnets when `true`, otherwise private subnets. Default: `false`.                             |
-| `taskExecutionRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                      | Extra inline policies merged into the generated execution role. Default: `[]`.                               |
-| `taskRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                               | Extra inline policies merged into the generated task role. Default: `[]`.                                    |
-| `enableServiceAutoDiscovery`<br/>`pulumi.Input<boolean>`                                                                               | Creates a private DNS namespace and Cloud Map service. Default: `false`.                                     |
-| `autoscaling`<br/>`pulumi.Input<{ enabled: pulumi.Input<boolean>; minCount?: pulumi.Input<number>; maxCount?: pulumi.Input<number> }>` | ECS target-tracking autoscaling configuration. Default: disabled.                                            |
-| `tags`<br/>`pulumi.Input<EcsService.Tags>`                                                                                             | Additional tags merged with the package common tags.                                                         |
+| Property                                                                                                                               | Description                                                                                                      |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `cluster`\*<br/>`pulumi.Input<aws.ecs.Cluster>`                                                                                        | ECS cluster that will run the service.                                                                           |
+| `vpc`\*<br/>`pulumi.Input<awsx.ec2.Vpc>`                                                                                               | Provides subnets, VPC ID, and CIDR-based security group rules.                                                   |
+| `containers`\*<br/>`EcsService.Container[]`                                                                                            | Full task container list.                                                                                        |
+| `loadBalancers`<br/>`pulumi.Input<EcsService.LoadBalancerConfig[]>`                                                                    | Optional ECS service-to-target-group registrations.                                                              |
+| `volumes`<br/>`pulumi.Input<pulumi.Input<EcsService.PersistentStorageVolume>[]>`                                                       | Any non-empty value triggers creation of shared EFS-backed persistent storage. Default: `[]`.                    |
+| `name`<br/>`pulumi.Input<string>`                                                                                                      | ECS service name override. Default: component name.                                                              |
+| `deploymentController`<br/>`'ECS' \| 'CODE_DEPLOY' \| 'EXTERNAL'`                                                                      | ECS deployment controller type. Default: `'ECS'`.                                                                |
+| `desiredCount`<br/>`pulumi.Input<number>`                                                                                              | Initial desired task count. Default: `1`.                                                                        |
+| `family`<br/>`pulumi.Input<string>`                                                                                                    | Task definition family. Default: `<name>-task-definition-<stack>`.                                               |
+| `size`<br/>`pulumi.Input<TaskSize>`                                                                                                    | CPU/memory preset or explicit `{ cpu, memory }` object. Default: `'small'`.                                      |
+| `logGroupNamePrefix`<br/>`pulumi.Input<string>`                                                                                        | Passed to `aws.cloudwatch.LogGroup.namePrefix`. Default: `/ecs/<name>-`.                                         |
+| `securityGroup`<br/>`pulumi.Input<aws.ec2.SecurityGroup>`                                                                              | If omitted, the component creates a VPC-wide internal service security group. Default: generated default SG.     |
+| `assignPublicIp`<br/>`pulumi.Input<boolean>`                                                                                           | Selects public subnets when `true`, otherwise private subnets. Default: `false`.                                 |
+| `taskExecutionRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                      | Extra inline policies merged into the generated execution role. Default: `[]`.                                   |
+| `taskRoleInlinePolicies`<br/>`pulumi.Input<pulumi.Input<EcsService.RoleInlinePolicy>[]>`                                               | Extra inline policies merged into the generated task role. Default: `[]`.                                        |
+| `enableServiceAutoDiscovery`<br/>`pulumi.Input<boolean>`                                                                               | Creates a private DNS namespace and Cloud Map service. Default: `false`.                                         |
+| `autoscaling`<br/>`pulumi.Input<{ enabled: pulumi.Input<boolean>; minCount?: pulumi.Input<number>; maxCount?: pulumi.Input<number> }>` | ECS target-tracking autoscaling configuration. Default: disabled.                                                |
+| `region`<br/>`pulumi.Input<string>`                                                                                                    | AWS region used for region-specific ECS settings such as CloudWatch Logs. Default: active AWS provider's region. |
+| `tags`<br/>`pulumi.Input<EcsService.Tags>`                                                                                             | Additional tags merged with the package common tags.                                                             |
 
 **Outputs**
 

--- a/src/components/ecs-service/index.ts
+++ b/src/components/ecs-service/index.ts
@@ -3,11 +3,9 @@ import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import { commonTags } from '../../shared/common-tags';
 import { mergeWithDefaults } from '../../shared/merge-with-defaults';
+import { resolveAwsRegion } from '../../shared/resolve-aws-region';
 import { assumeRolePolicy } from './policies';
 import { TaskSize, parseTaskSize } from './task-size';
-
-const config = new pulumi.Config('aws');
-const awsRegion = config.require('region');
 
 export namespace EcsService {
   /**
@@ -158,6 +156,11 @@ export namespace EcsService {
       maxCount?: pulumi.Input<number>;
     }>;
     /**
+     * AWS region used for region-specific ECS settings such as CloudWatch Logs.
+     * When omitted, the region is resolved from the active AWS provider.
+     */
+    region?: pulumi.Input<string>;
+    /**
      * A map of tags to assign to the resource.
      */
     tags?: pulumi.Input<EcsService.Tags>;
@@ -223,6 +226,7 @@ export class EcsService extends pulumi.ComponentResource {
       },
     );
     const argsWithDefaults = mergeWithDefaults(defaults, args);
+    const region = resolveAwsRegion(argsWithDefaults, this);
     const taskExecutionRoleInlinePolicies = pulumi.output(
       args.taskExecutionRoleInlinePolicies ||
         defaults.taskExecutionRoleInlinePolicies,
@@ -253,6 +257,7 @@ export class EcsService extends pulumi.ComponentResource {
       argsWithDefaults.family,
       argsWithDefaults.size,
       { ...commonTags, ...argsWithDefaults.tags },
+      region,
     );
 
     if (argsWithDefaults.enableServiceAutoDiscovery) {
@@ -304,11 +309,12 @@ export class EcsService extends pulumi.ComponentResource {
     family: pulumi.Input<string> | undefined,
     size: pulumi.Input<TaskSize>,
     tags: pulumi.Input<EcsService.Tags>,
+    region: pulumi.Input<string>,
   ): pulumi.Output<aws.ecs.TaskDefinition> {
     const stack = pulumi.getStack();
     const { cpu, memory } = pulumi.output(size).apply(parseTaskSize);
     const containerDefinitions = containers.map(container => {
-      return this.createContainerDefinition(container);
+      return this.createContainerDefinition(container, region);
     });
 
     const taskDefinitionVolumes = this.createTaskDefinitionVolumes(volumes);
@@ -357,34 +363,39 @@ export class EcsService extends pulumi.ComponentResource {
       });
   }
 
-  private createContainerDefinition(container: EcsService.Container) {
-    return this.logGroup.name.apply(logGroupName => ({
-      ...container,
-      readonlyRootFilesystem: false,
-      ...(container.mountPoints && {
-        mountPoints: container.mountPoints.map(mountPoint =>
-          pulumi
-            .all([
-              mountPoint.sourceVolume,
-              mountPoint.containerPath,
-              mountPoint.readOnly,
-            ])
-            .apply(([sourceVolume, containerPath, readOnly]) => ({
-              containerPath,
-              sourceVolume,
-              readOnly: readOnly ?? false,
-            })),
-        ),
-      }),
-      logConfiguration: {
-        logDriver: 'awslogs',
-        options: {
-          'awslogs-group': logGroupName,
-          'awslogs-region': awsRegion,
-          'awslogs-stream-prefix': 'ecs',
+  private createContainerDefinition(
+    container: EcsService.Container,
+    region: pulumi.Input<string>,
+  ) {
+    return pulumi
+      .all([this.logGroup.name, region])
+      .apply(([logGroupName, region]) => ({
+        ...container,
+        readonlyRootFilesystem: false,
+        ...(container.mountPoints && {
+          mountPoints: container.mountPoints.map(mountPoint =>
+            pulumi
+              .all([
+                mountPoint.sourceVolume,
+                mountPoint.containerPath,
+                mountPoint.readOnly,
+              ])
+              .apply(([sourceVolume, containerPath, readOnly]) => ({
+                containerPath,
+                sourceVolume,
+                readOnly: readOnly ?? false,
+              })),
+          ),
+        }),
+        logConfiguration: {
+          logDriver: 'awslogs',
+          options: {
+            'awslogs-group': logGroupName,
+            'awslogs-region': region,
+            'awslogs-stream-prefix': 'ecs',
+          },
         },
-      },
-    }));
+      }));
   }
 
   private createTaskExecutionRole(

--- a/src/components/grafana/README.md
+++ b/src/components/grafana/README.md
@@ -15,6 +15,7 @@ import * as studion from '@studion/infra-code-blocks';
 const workspace = new aws.amp.Workspace('api-metrics', {});
 
 const grafana = new studion.grafana.GrafanaBuilder('service-observability')
+  .withStackSlug('exampleslug')
   .withFolderName('Service Observability')
   .addPlugin({
     name: 'amp',
@@ -67,7 +68,12 @@ const overviewDashboard = new studion.grafana.dashboard.DashboardBuilder(
   )
   .build();
 
+const stackSlug = studion.grafana.Grafana.getStackSlug(
+  'https://example.grafana.net',
+);
+
 const grafana = new studion.grafana.GrafanaBuilder('platform-observability')
+  .withStackSlug(stackSlug)
   .withFolderName('Platform Observability')
   .withServiceAccountTokenRotation({
     secondsToLive: 86_400,
@@ -113,19 +119,19 @@ export const dataSourceNames = grafana.connections.map(
 
 ## Implementation notes
 
-- `Grafana` reads the Grafana URL from Pulumi config `grafana:url` or environment variable `GRAFANA_URL`, parses it with JavaScript `URL`, and derives the Grafana Cloud stack slug from the first hostname label.
-- Malformed Grafana URLs fail during slug derivation before stack lookup, so the configured URL must include a valid URL format such as `https://<stack>.grafana.net`.
+- `Grafana` requires `stackSlug` as explicit constructor input and uses it to resolve the Grafana Cloud stack metadata.
+- Use `Grafana.getStackSlug(grafanaUrl)` when you have a Grafana Cloud URL and need to derive the stack slug from the first hostname label, for example `https://<stack>.grafana.net` -> `<stack>`.
 - Creating the initial Grafana Cloud resources still requires a Grafana Cloud access policy token supplied through the Grafana provider configuration, typically `grafana:cloudAccessPolicyToken` or `GRAFANA_CLOUD_ACCESS_POLICY_TOKEN`. Required scopes: `accesspolicies:read`, `accesspolicies:write`, `accesspolicies:delete`, `stacks:read`, `stack-service-accounts:write`.
 - The access policy created by this component always includes these package-required scopes: `accesspolicies:read`, `accesspolicies:write`, `accesspolicies:delete`, `datasources:read`, `datasources:write`, `datasources:delete`, `stacks:read`, `stack-dashboards:read`, `stack-dashboards:write`, `stack-dashboards:delete`, `stack-plugins:read`, `stack-plugins:write`, and `stack-plugins:delete`.
 - User-provided `scopes` are merged with the required scopes using `Set`, so duplicate scope strings are removed before the access policy is created.
 - The component creates an access-policy rotating token first, then a stack service account with `Admin` role, then a service-account rotating token, and finally a Grafana provider that uses both generated tokens.
 - Plugins declared on `Grafana.Args.plugins` or added through `GrafanaBuilder.addPlugin()` are installed by the top-level `Grafana` component before dependent resources are created.
 - Plugins added with `addPlugin()` are accumulated in insertion order and forwarded to `Grafana.Args.plugins` during `build()`.
-- Each declared plugin creates a `grafana.cloud.PluginInstallation` resource exposed through `Grafana.plugins` plus an internal `PluginReady` resource that polls the resolved `grafanaUrl` until the plugin is available.
+- Each declared plugin creates a `grafana.cloud.PluginInstallation` resource exposed through `Grafana.plugins` plus an internal `PluginReady` resource that polls the resolved stack URL until the plugin is available.
 - Connections are created after the internal `PluginReady` checks, so plugin-backed data sources such as AMP and X-Ray assume plugin availability from the surrounding `Grafana` setup or from externally preinstalled plugins.
 - The rotating tokens default to 90-day lifetimes with a 7-day early rotation window and `deleteOnDestroy: true`.
 - If `folderName` is omitted, dashboards are placed in a folder named `${name}-ICB-GENERATED`.
-- `GrafanaBuilder.build()` throws unless you add at least one connection and at least one dashboard.
+- `GrafanaBuilder.build()` throws unless you set a stack slug and add at least one connection and at least one dashboard.
 - Connection-specific behavior and data-source details are documented in [`connections`](connections/README.md).
 - Dashboard builder constraints, variables, and generated dashboard layouts are documented in [`dashboards`](dashboards/README.md).
 - Panel helper defaults, thresholds, table/traces primitives, and grid positions are documented in [`panels`](panels/README.md).
@@ -161,6 +167,7 @@ Direct constructor input: `args: Grafana.Args`
 
 | Property                                                                | Description                                                                                                                 |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `stackSlug`\*<br/>`string`                                              | Grafana Cloud stack slug used to resolve stack metadata, configure the generated provider, and run plugin readiness checks. |
 | `connectionBuilders`\*<br/>`GrafanaConnection.CreateConnection[]`       | Factories invoked with `{ stack }` and provider-scoped `opts` to create connection components.                              |
 | `dashboardBuilders`\*<br/>`DashboardBuilder.CreateDashboard[]`          | Factories invoked with the generated folder and provider-scoped `opts` to create dashboards.                                |
 | `folderName`<br/>`string`                                               | Title for the generated Grafana folder. Default: `<name>-ICB-GENERATED`.                                                    |
@@ -174,13 +181,12 @@ Direct constructor input: `args: Grafana.Args`
 | Property                                                                   | Description                                                                                                                                                                                                       |
 | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`<br/>`string`                                                        | Component name.                                                                                                                                                                                                   |
-| `grafanaUrl`<br/>`string`                                                  | Resolved Grafana URL used for plugin readiness checks and downstream consumers.                                                                                                                                   |
 | `stack`<br/>`pulumi.Output<grafana.cloud.GetStackResult>`                  | Resolved Grafana Cloud stack metadata.                                                                                                                                                                            |
 | `accessPolicy`<br/>`grafana.cloud.AccessPolicy`                            | Access policy created for data source and dashboard provisioning.                                                                                                                                                 |
 | `accessPolicyToken`<br/>`grafana.cloud.AccessPolicyRotatingToken`          | Rotating token for the generated access policy.                                                                                                                                                                   |
 | `serviceAccount`<br/>`grafana.cloud.StackServiceAccount`                   | Service account used by the Grafana provider.                                                                                                                                                                     |
 | `serviceAccountToken`<br/>`grafana.cloud.StackServiceAccountRotatingToken` | Rotating token for the generated service account.                                                                                                                                                                 |
-| `provider`<br/>`grafana.Provider`                                          | Grafana provider configured with the generated URL and auth token.                                                                                                                                                |
+| `provider`<br/>`grafana.Provider`                                          | Grafana provider configured with the resolved stack URL and auth token.                                                                                                                                           |
 | `plugins`<br/>`grafana.cloud.PluginInstallation[] \| undefined`            | Grafana Cloud plugin installation resources created for declared plugins. Use this when you need to reference the installation resources directly; readiness polling is handled internally through `PluginReady`. |
 | `folder`<br/>`grafana.oss.Folder`                                          | Folder created for all dashboards built by the component.                                                                                                                                                         |
 | `dashboards`<br/>`grafana.oss.Dashboard[]`                                 | Dashboards created from `dashboardBuilders`, in insertion order.                                                                                                                                                  |
@@ -231,6 +237,16 @@ type AccessPolicyTokenRotation = {
 | `expireAfter`\*<br/>`string`         | Token lifetime string passed to the Grafana provider.  |
 | `earlyRotationWindow`\*<br/>`string` | Rotation window string passed to the Grafana provider. |
 
+**Helper Methods**
+
+**`Grafana.getStackSlug`**
+
+```ts
+Grafana.getStackSlug(grafanaUrl: string): string
+```
+
+Parses a Grafana Cloud URL and returns the first hostname label to use as `Grafana.Args.stackSlug`.
+
 ### `grafana.GrafanaBuilder`
 
 **Signature**
@@ -249,21 +265,22 @@ class GrafanaBuilder {
 
 **Builder Methods**
 
-| Method                            | Parameters                                                         | Description                                                                                                  |
-| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `withFolderName`                  | `folderName: string`                                               | Sets `Grafana.Args.folderName`.                                                                              |
-| `withServiceAccountTokenRotation` | `rotation: Grafana.ServiceAccountTokenRotation`                    | Sets `Grafana.Args.serviceAccountTokenRotation`.                                                             |
-| `withAccessPolicyTokenRotation`   | `rotation: Grafana.AccessPolicyTokenRotation`                      | Sets `Grafana.Args.accessPolicyTokenRotation`.                                                               |
-| `addScope`                        | `...scopes: string[]`                                              | Appends scopes that will later be merged into `Grafana.Args.scopes`.                                         |
-| `addPlugin`                       | `plugin: Grafana.PluginArgs`                                       | Declares a Grafana plugin to install before building plugin-backed data sources and dashboards.              |
-| `addAmp`                          | `name: string, args: Omit<AMPConnection.Args, 'stack'>`            | Appends an AMP connection factory. See [`connections`](connections/README.md).                               |
-| `addCloudWatchLogs`               | `name: string, args: Omit<CloudWatchLogsConnection.Args, 'stack'>` | Appends a CloudWatch Logs connection factory. See [`connections`](connections/README.md).                    |
-| `addXRay`                         | `name: string, args: Omit<XRayConnection.Args, 'stack'>`           | Appends an X-Ray connection factory. See [`connections`](connections/README.md).                             |
-| `addConnection`                   | `builder: GrafanaConnection.CreateConnection`                      | Appends a custom connection factory. See [`connections`](connections/README.md).                             |
-| `addSloDashboard`                 | `config: SloDashboard.Args`                                        | Appends `createSloDashboard(config)`. See [`dashboards`](dashboards/README.md).                              |
-| `addLogsAndTracesDashboard`       | `config: LogsAndTracesDashboard.Args`                              | Appends `createLogsAndTracesDashboard(config)`. See [`dashboards`](dashboards/README.md).                    |
-| `addDashboard`                    | `dashboard: DashboardBuilder.CreateDashboard`                      | Appends a custom dashboard factory. See [`dashboards`](dashboards/README.md).                                |
-| `build`                           | `opts?: pulumi.ComponentResourceOptions`                           | Constructs `Grafana` from the accumulated values. Throws if no connections or no dashboards have been added. |
+| Method                            | Parameters                                                         | Description                                                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `withStackSlug`                   | `stackSlug: string`                                                | Sets the required `Grafana.Args.stackSlug`; must be called before `build()`.                                                 |
+| `withFolderName`                  | `folderName: string`                                               | Sets `Grafana.Args.folderName`.                                                                                              |
+| `withServiceAccountTokenRotation` | `rotation: Grafana.ServiceAccountTokenRotation`                    | Sets `Grafana.Args.serviceAccountTokenRotation`.                                                                             |
+| `withAccessPolicyTokenRotation`   | `rotation: Grafana.AccessPolicyTokenRotation`                      | Sets `Grafana.Args.accessPolicyTokenRotation`.                                                                               |
+| `addScope`                        | `...scopes: string[]`                                              | Appends scopes that will later be merged into `Grafana.Args.scopes`.                                                         |
+| `addPlugin`                       | `plugin: Grafana.PluginArgs`                                       | Declares a Grafana plugin to install before building plugin-backed data sources and dashboards.                              |
+| `addAmp`                          | `name: string, args: Omit<AMPConnection.Args, 'stack'>`            | Appends an AMP connection factory. See [`connections`](connections/README.md).                                               |
+| `addCloudWatchLogs`               | `name: string, args: Omit<CloudWatchLogsConnection.Args, 'stack'>` | Appends a CloudWatch Logs connection factory. See [`connections`](connections/README.md).                                    |
+| `addXRay`                         | `name: string, args: Omit<XRayConnection.Args, 'stack'>`           | Appends an X-Ray connection factory. See [`connections`](connections/README.md).                                             |
+| `addConnection`                   | `builder: GrafanaConnection.CreateConnection`                      | Appends a custom connection factory. See [`connections`](connections/README.md).                                             |
+| `addSloDashboard`                 | `config: SloDashboard.Args`                                        | Appends `createSloDashboard(config)`. See [`dashboards`](dashboards/README.md).                                              |
+| `addLogsAndTracesDashboard`       | `config: LogsAndTracesDashboard.Args`                              | Appends `createLogsAndTracesDashboard(config)`. See [`dashboards`](dashboards/README.md).                                    |
+| `addDashboard`                    | `dashboard: DashboardBuilder.CreateDashboard`                      | Appends a custom dashboard factory. See [`dashboards`](dashboards/README.md).                                                |
+| `build`                           | `opts?: pulumi.ComponentResourceOptions`                           | Constructs `Grafana` from the accumulated values. Throws if no stack slug, no connections, or no dashboards have been added. |
 
 **Build Result**
 

--- a/src/components/grafana/builder.ts
+++ b/src/components/grafana/builder.ts
@@ -21,12 +21,19 @@ export class GrafanaBuilder {
     [];
   private readonly scopes: string[] = [];
   private readonly plugins: Grafana.PluginArgs[] = [];
+  private stackSlug?: string;
   private folderName?: string;
   private serviceAccountTokenRotation?: Grafana.ServiceAccountTokenRotation;
   private accessPolicyTokenRotation?: Grafana.AccessPolicyTokenRotation;
 
   constructor(name: string) {
     this.name = name;
+  }
+
+  public withStackSlug(stackSlug: string): this {
+    this.stackSlug = stackSlug;
+
+    return this;
   }
 
   public withFolderName(folderName: string): this {
@@ -118,6 +125,12 @@ export class GrafanaBuilder {
   }
 
   public build(opts: pulumi.ComponentResourceOptions = {}): Grafana {
+    if (!this.stackSlug) {
+      throw new Error(
+        'Stack slug not provided. Make sure to call GrafanaBuilder.withStackSlug().',
+      );
+    }
+
     if (!this.connectionBuilders.length) {
       throw new Error(
         'At least one connection is required. Call addConnection() to add a custom connection or use one of the existing connection builders.',
@@ -133,6 +146,7 @@ export class GrafanaBuilder {
     return new Grafana(
       this.name,
       {
+        stackSlug: this.stackSlug,
         connectionBuilders: this.connectionBuilders,
         dashboardBuilders: this.dashboardBuilders,
         folderName: this.folderName,

--- a/src/components/grafana/connections/README.md
+++ b/src/components/grafana/connections/README.md
@@ -33,6 +33,7 @@ const overviewDashboard = new studion.grafana.dashboard.DashboardBuilder(
   .build();
 
 const grafana = new studion.grafana.GrafanaBuilder('platform-observability')
+  .withStackSlug('exampleslug')
   .addPlugin({
     name: 'amp',
     slug: 'grafana-amazonprometheus-datasource',
@@ -69,7 +70,7 @@ import * as studion from '@studion/infra-code-blocks';
 
 type CustomMetricsConnectionArgs = studion.grafana.GrafanaConnection.Args & {
   endpoint: pulumi.Input<string>;
-  region: string;
+  region: pulumi.Input<string>;
 };
 
 class CustomMetricsConnection extends studion.grafana.GrafanaConnection {
@@ -155,6 +156,7 @@ const tracesDashboard = new studion.grafana.dashboard.DashboardBuilder('traces')
   .build();
 
 const grafana = new studion.grafana.GrafanaBuilder('custom-observability')
+  .withStackSlug('exampleslug')
   .addConnection(
     (ctx, opts) =>
       new CustomMetricsConnection(
@@ -214,7 +216,7 @@ export const customDataSourceName = grafana.connections[0].dataSource.name;
 - Concrete connection subclasses create their own Grafana data source and any additional IAM role policies.
 - `addConnection()` is the extension point for registering built-in or custom connection classes with `GrafanaBuilder`.
 - `GrafanaBuilder` helpers such as `addAmp()`, `addCloudWatchLogs()`, and `addXRay()` are convenience wrappers for common built-in connection classes.
-- The built-in connection modules read Pulumi config `aws:region` for their default region at module load time; provide that config whenever these classes are imported.
+- Built-in AWS connection classes use an explicit `region` when provided and otherwise derive the region from the active AWS provider.
 - AMP and X-Ray still create plugin-backed Grafana data source types, so the matching plugins must be declared on the surrounding `Grafana` / `GrafanaBuilder` or preinstalled externally.
 - `AMPConnection` creates a `grafana-amazonprometheus-datasource` data source configured for SigV4 assume-role auth against the connection IAM role.
 - `XRayConnection` creates a `grafana-x-ray-datasource` data source configured for assume-role auth against the connection IAM role.
@@ -327,13 +329,13 @@ class AMPConnection extends GrafanaConnection {
 
 Direct constructor input: `args: AMPConnection.Args`
 
-| Property                                                   | Description                                                                              |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.             |
-| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.             |
-| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`. |
-| `endpoint`\*<br/>`pulumi.Input<string>`                    | AMP workspace endpoint used as the data source URL.                                      |
-| `region`<br/>`string`                                      | AWS region written into SigV4 data source configuration. Default: `aws:region`.          |
+| Property                                                   | Description                                                                                                                                                 |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.                                                                                |
+| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.                                                                                |
+| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`.                                                                    |
+| `endpoint`\*<br/>`pulumi.Input<string>`                    | AMP workspace endpoint used as the data source URL.                                                                                                         |
+| `region`<br/>`pulumi.Input<string>`                        | AWS region written into SigV4 data source configuration. Uses this explicit value when provided; otherwise derives the region from the active AWS provider. |
 
 **Outputs**
 
@@ -375,12 +377,12 @@ class CloudWatchLogsConnection extends GrafanaConnection {
 
 Direct constructor input: `args: CloudWatchLogsConnection.Args`
 
-| Property                                                   | Description                                                                              |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.             |
-| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.             |
-| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`. |
-| `region`<br/>`string`                                      | AWS region written to `jsonDataEncoded.defaultRegion`. Default: `aws:region`.            |
+| Property                                                   | Description                                                                                                                                               |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.                                                                              |
+| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.                                                                              |
+| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`.                                                                  |
+| `region`<br/>`pulumi.Input<string>`                        | AWS region written to `jsonDataEncoded.defaultRegion`. Uses this explicit value when provided; otherwise derives the region from the active AWS provider. |
 
 **Outputs**
 
@@ -417,12 +419,12 @@ class XRayConnection extends GrafanaConnection {
 
 Direct constructor input: `args: XRayConnection.Args`
 
-| Property                                                   | Description                                                                              |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.             |
-| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.             |
-| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`. |
-| `region`<br/>`string`                                      | AWS region written to the X-Ray data source configuration. Default: `aws:region`.        |
+| Property                                                   | Description                                                                                                                                                   |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `awsAccountId`\*<br/>`string`                              | AWS account ID whose root principal is allowed to assume the generated role.                                                                                  |
+| `dataSourceName`<br/>`string`                              | Display name used for the Grafana data source. Default: `<name>-datasource`.                                                                                  |
+| `stack`\*<br/>`pulumi.Input<grafana.cloud.GetStackResult>` | Grafana Cloud stack metadata used for IAM trust and supplied by the enclosing `Grafana`.                                                                      |
+| `region`<br/>`pulumi.Input<string>`                        | AWS region written to the X-Ray data source configuration. Uses this explicit value when provided; otherwise derives the region from the active AWS provider. |
 
 **Outputs**
 

--- a/src/components/grafana/connections/amp-connection.ts
+++ b/src/components/grafana/connections/amp-connection.ts
@@ -1,21 +1,15 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
-import { mergeWithDefaults } from '../../../shared/merge-with-defaults';
+import { resolveAwsRegion } from '../../../shared/resolve-aws-region';
 import { GrafanaConnection } from './connection';
-
-const awsConfig = new pulumi.Config('aws');
 
 export namespace AMPConnection {
   export type Args = GrafanaConnection.Args & {
     endpoint: pulumi.Input<string>;
-    region?: string;
+    region?: pulumi.Input<string>;
   };
 }
-
-const defaults = {
-  region: awsConfig.require('region'),
-};
 
 export class AMPConnection extends GrafanaConnection {
   public readonly name: string;
@@ -29,16 +23,13 @@ export class AMPConnection extends GrafanaConnection {
   ) {
     super('studion:grafana:AMPConnection', name, args, opts);
 
-    const argsWithDefaults = mergeWithDefaults(defaults, args);
+    const region = resolveAwsRegion(args, this);
 
     this.name = name;
 
     this.rolePolicy = this.createRolePolicy();
 
-    this.dataSource = this.createDataSource(
-      argsWithDefaults.region,
-      argsWithDefaults.endpoint,
-    );
+    this.dataSource = this.createDataSource(args.endpoint, region);
 
     this.registerOutputs();
   }
@@ -70,8 +61,8 @@ export class AMPConnection extends GrafanaConnection {
   }
 
   private createDataSource(
-    region: string,
     endpoint: AMPConnection.Args['endpoint'],
+    region: AMPConnection.Args['region'],
   ): grafana.oss.DataSource {
     return new grafana.oss.DataSource(
       `${this.name}-amp-datasource`,

--- a/src/components/grafana/connections/cloudwatch-logs-connection.ts
+++ b/src/components/grafana/connections/cloudwatch-logs-connection.ts
@@ -1,20 +1,14 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
-import { mergeWithDefaults } from '../../../shared/merge-with-defaults';
+import { resolveAwsRegion } from '../../../shared/resolve-aws-region';
 import { GrafanaConnection } from './connection';
-
-const awsConfig = new pulumi.Config('aws');
 
 export namespace CloudWatchLogsConnection {
   export type Args = GrafanaConnection.Args & {
-    region?: string;
+    region?: pulumi.Input<string>;
   };
 }
-
-const defaults = {
-  region: awsConfig.require('region'),
-};
 
 export class CloudWatchLogsConnection extends GrafanaConnection {
   public readonly name: string;
@@ -28,12 +22,12 @@ export class CloudWatchLogsConnection extends GrafanaConnection {
   ) {
     super('studion:grafana:CloudWatchLogsConnection', name, args, opts);
 
-    const argsWithDefaults = mergeWithDefaults(defaults, args);
+    const region = resolveAwsRegion(args, this);
 
     this.name = name;
 
     this.rolePolicy = this.createRolePolicy();
-    this.dataSource = this.createDataSource(argsWithDefaults.region);
+    this.dataSource = this.createDataSource(region);
 
     this.registerOutputs();
   }
@@ -66,7 +60,9 @@ export class CloudWatchLogsConnection extends GrafanaConnection {
     );
   }
 
-  private createDataSource(region: string): grafana.oss.DataSource {
+  private createDataSource(
+    region: CloudWatchLogsConnection.Args['region'],
+  ): grafana.oss.DataSource {
     return new grafana.oss.DataSource(
       `${this.name}-cloudwatch-logs-datasource`,
       {

--- a/src/components/grafana/connections/xray-connection.ts
+++ b/src/components/grafana/connections/xray-connection.ts
@@ -1,19 +1,14 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import * as grafana from '@pulumiverse/grafana';
-import { mergeWithDefaults } from '../../../shared/merge-with-defaults';
+import { resolveAwsRegion } from '../../../shared/resolve-aws-region';
 import { GrafanaConnection } from './connection';
 
-const awsConfig = new pulumi.Config('aws');
 export namespace XRayConnection {
   export type Args = GrafanaConnection.Args & {
-    region?: string;
+    region?: pulumi.Input<string>;
   };
 }
-
-const defaults = {
-  region: awsConfig.require('region'),
-};
 
 export class XRayConnection extends GrafanaConnection {
   public readonly name: string;
@@ -27,13 +22,13 @@ export class XRayConnection extends GrafanaConnection {
   ) {
     super('studion:grafana:XRayConnection', name, args, opts);
 
-    const argsWithDefaults = mergeWithDefaults(defaults, args);
+    const region = resolveAwsRegion(args, this);
 
     this.name = name;
 
     this.rolePolicy = this.createRolePolicy();
 
-    this.dataSource = this.createDataSource(argsWithDefaults.region);
+    this.dataSource = this.createDataSource(region);
 
     this.registerOutputs();
   }
@@ -69,7 +64,9 @@ export class XRayConnection extends GrafanaConnection {
     );
   }
 
-  private createDataSource(region: string): grafana.oss.DataSource {
+  private createDataSource(
+    region: XRayConnection.Args['region'],
+  ): grafana.oss.DataSource {
     return new grafana.oss.DataSource(
       `${this.name}-x-ray-datasource`,
       {

--- a/src/components/grafana/grafana.ts
+++ b/src/components/grafana/grafana.ts
@@ -50,6 +50,7 @@ export namespace Grafana {
   };
 
   export type Args = {
+    stackSlug: string;
     connectionBuilders: GrafanaConnection.CreateConnection[];
     dashboardBuilders: GrafanaDashboardBuilder.CreateDashboard[];
     folderName?: string;
@@ -67,7 +68,6 @@ export namespace Grafana {
  */
 export class Grafana extends pulumi.ComponentResource {
   public readonly name: string;
-  public readonly grafanaUrl: string;
   public readonly stack: pulumi.Output<grafana.cloud.GetStackResult>;
   public readonly accessPolicy: grafana.cloud.AccessPolicy;
   public readonly accessPolicyToken: grafana.cloud.AccessPolicyRotatingToken;
@@ -89,9 +89,9 @@ export class Grafana extends pulumi.ComponentResource {
     const argsWithDefaults = mergeWithDefaults(defaults, args);
 
     this.name = name;
-
-    this.grafanaUrl = this.getGrafanaUrl();
-    this.stack = grafana.cloud.getStackOutput({ slug: this.getStackSlug() });
+    this.stack = grafana.cloud.getStackOutput({
+      slug: argsWithDefaults.stackSlug,
+    });
 
     this.accessPolicy = this.createAccessPolicy(argsWithDefaults.scopes);
     this.accessPolicyToken = this.createAccessPolicyToken(
@@ -141,21 +141,8 @@ export class Grafana extends pulumi.ComponentResource {
     this.registerOutputs();
   }
 
-  private getGrafanaUrl(): string {
-    const grafanaConfig = new pulumi.Config('grafana');
-    const grafanaUrl = grafanaConfig.get('url') ?? process.env.GRAFANA_URL;
-
-    if (!grafanaUrl) {
-      throw new Error(
-        'Grafana URL is not configured. Set it via Pulumi config (grafana:url) or GRAFANA_URL env var.',
-      );
-    }
-
-    return grafanaUrl;
-  }
-
-  private getStackSlug(): string {
-    return new URL(this.grafanaUrl).hostname.split('.')[0];
+  public static getStackSlug(grafanaUrl: string): string {
+    return new URL(grafanaUrl).hostname.split('.')[0];
   }
 
   private createAccessPolicy(scopes?: string[]): grafana.cloud.AccessPolicy {
@@ -248,8 +235,8 @@ export class Grafana extends pulumi.ComponentResource {
       `${this.name}-${name}-plugin-ready`,
       {
         grafanaToken: this.serviceAccountToken.key,
-        grafanaUrl: this.grafanaUrl,
-        pluginSlug: slug,
+        grafanaUrl: this.stack.url,
+        slug,
       },
       {
         dependsOn: [plugin],

--- a/src/components/grafana/plugin-ready.ts
+++ b/src/components/grafana/plugin-ready.ts
@@ -4,17 +4,35 @@ import { request } from 'undici';
 
 export namespace PluginReady {
   export type Args = {
-    grafanaToken: pulumi.Input<string>;
-    grafanaUrl: string;
-    pluginSlug: string;
+    grafanaToken: pulumi.Output<string>;
+    grafanaUrl: pulumi.Input<string>;
+    slug: pulumi.Input<string>;
   };
 }
 
-const pluginReadyProvider: pulumi.dynamic.ResourceProvider = {
-  async create(inputs: PluginReady.Args) {
-    const { grafanaToken, grafanaUrl, pluginSlug } = inputs;
+export class PluginReady extends pulumi.dynamic.Resource {
+  constructor(
+    name: string,
+    props: PluginReady.Args,
+    opts?: pulumi.CustomResourceOptions,
+  ) {
+    super(new PluginReadyProvider(), name, props, opts);
+  }
+}
 
-    const url = new URL(`/api/plugins/${pluginSlug}/settings`, grafanaUrl).href;
+type PluginReadyProviderInputs = {
+  grafanaToken: string;
+  grafanaUrl: string;
+  slug: string;
+};
+
+class PluginReadyProvider implements pulumi.dynamic.ResourceProvider {
+  async create(
+    inputs: PluginReadyProviderInputs,
+  ): Promise<pulumi.dynamic.CreateResult> {
+    const { grafanaToken, grafanaUrl, slug } = inputs;
+
+    const url = new URL(`/api/plugins/${slug}/settings`, grafanaUrl).href;
 
     let data: { id: string };
     try {
@@ -49,21 +67,9 @@ const pluginReadyProvider: pulumi.dynamic.ResourceProvider = {
         },
       );
     } catch {
-      throw new Error(
-        `Timed out waiting for plugin "${pluginSlug}" to become ready`,
-      );
+      throw new Error(`Timed out waiting for plugin "${slug}" to become ready`);
     }
 
     return { id: data.id, outs: {} };
-  },
-};
-
-export class PluginReady extends pulumi.dynamic.Resource {
-  constructor(
-    name: string,
-    props: PluginReady.Args,
-    opts?: pulumi.CustomResourceOptions,
-  ) {
-    super(pluginReadyProvider, name, props, opts);
   }
 }

--- a/src/shared/resolve-aws-region.ts
+++ b/src/shared/resolve-aws-region.ts
@@ -1,0 +1,23 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+
+type RegionAwareArgs = {
+  region?: pulumi.Input<string>;
+};
+
+export function resolveAwsRegion(
+  { region }: RegionAwareArgs,
+  parent: pulumi.Resource,
+): pulumi.Output<string> {
+  return region
+    ? pulumi.output(region)
+    : aws.getRegionOutput({}, { parent }).region.apply(resolvedRegion => {
+        if (!resolvedRegion) {
+          throw new Error(
+            'AWS region could not be resolved from the active AWS provider. Configure the AWS provider region or pass region explicitly.',
+          );
+        }
+
+        return resolvedRegion;
+      });
+}

--- a/tests/grafana/infrastructure/index.ts
+++ b/tests/grafana/infrastructure/index.ts
@@ -67,9 +67,12 @@ const webServer = new studion.WebServerBuilder(appName)
   .build({ parent });
 
 const awsAccountId = process.env.GRAFANA_AWS_ACCOUNT_ID!;
+const grafanaUrl = process.env.GRAFANA_URL!;
+const stackSlug = studion.grafana.Grafana.getStackSlug(grafanaUrl);
 
 const ampDataSourceName = `${appName}-amp-datasource`;
 const ampGrafana = new studion.grafana.GrafanaBuilder(`${appName}-amp`)
+  .withStackSlug(stackSlug)
   .addPlugin({
     name: 'amp',
     slug: 'grafana-amazonprometheus-datasource',
@@ -97,6 +100,7 @@ const configurableAmpDataSourceName = `${appName}-configurable-amp-datasource`;
 const configurableGrafana = new studion.grafana.GrafanaBuilder(
   `${appName}-configurable`,
 )
+  .withStackSlug(stackSlug)
   .withFolderName('ICB Configurable Test Folder')
   .addConnection(
     (ctx, opts) =>
@@ -147,6 +151,7 @@ const xRayDataSourceName = `${appName}-x-ray-datasource`;
 const logsAndTracesGrafana = new studion.grafana.GrafanaBuilder(
   `${appName}-logs-traces`,
 )
+  .withStackSlug(stackSlug)
   .addPlugin({
     name: 'x-ray',
     slug: 'grafana-x-ray-datasource',


### PR DESCRIPTION
Components no longer use the `pulumi.Config` underneath to retrieve values such as AWS region or Grafana URL. This removes the tight coupling with the "callers" stack config.
Components that rely on AWS region now expose the explicit `region` arg, with fallback to get the region from the active AWS provider, when not provided. The `Grafana` component now exposes the required `stackSlug` argument and the method `getStackSlug` to retrieve the stack from the provided Grafana URL. The internal implementation for plugin readiness using the dynamic provider is refactored to better support this change.