### PR TITLE
fix: disable `evaluateTargetHealth` for CloudFront Route 53 aliases

### DIFF
--- a/src/components/cloudfront/index.ts
+++ b/src/components/cloudfront/index.ts
@@ -280,7 +280,7 @@ export class CloudFront extends pulumi.ComponentResource {
                 {
                   name: this.distribution.domainName,
                   zoneId: this.distribution.hostedZoneId,
-                  evaluateTargetHealth: true,
+                  evaluateTargetHealth: false,
                 },
               ],
             },


### PR DESCRIPTION
AWS does not support health evaluation on CloudFront alias targets, as CloudFront handles it own health and availability internally.