### PR TITLE
fix: remove opentelemetry wrapper and export otel directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The package provides building blocks across four areas:
 | Networking and delivery | VPCs, ACM certificates, CloudFront, and static hosting                     | `Vpc`, `AcmCertificate`, `CloudFront`, `StaticSite`, `S3Assets`                                                   |
 | Compute                 | Generic ECS services and ALB-backed web services                           | `EcsService`, `WebServer`, `WebServerBuilder`, `WebServerLoadBalancer`                                            |
 | Data                    | PostgreSQL, replicas, SSM access helpers, Redis, and password storage      | `Database`, `DatabaseBuilder`, `DatabaseReplica`, `Ec2SSMConnect`, `ElastiCacheRedis`, `UpstashRedis`, `Password` |
-| Observability           | OpenTelemetry collector integration, Grafana resources, and PromQL helpers | `openTelemetry`, `grafana`, `prometheus`                                                                          |
+| Observability           | OpenTelemetry collector integration, Grafana resources, and PromQL helpers | `OtelCollector`, `OtelCollectorBuilder`, `grafana`, `prometheus`                                                  |
 
 ## Quick start
 
@@ -169,7 +169,7 @@ const cluster = new aws.ecs.Cluster('app-cluster', {});
 const logGroup = new aws.cloudwatch.LogGroup('app-otel-logs', {});
 const workspace = new aws.amp.Workspace('app-amp', {});
 
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder('app', env)
+const otelCollector = new studion.OtelCollectorBuilder('app', env)
   .withDefault({
     prometheusNamespace: 'app',
     prometheusWorkspace: workspace,
@@ -298,7 +298,8 @@ Keep that command running, then connect your database client to `localhost:5555`
 | `CloudFront`            | class     | Behavior-driven CloudFront distribution.       | [cloudfront](src/components/cloudfront/README.md)           |
 | `StaticSite`            | class     | S3 website plus CloudFront composition.        | [static-site](src/components/static-site/README.md)         |
 | `S3Assets`              | class     | Public S3 website bucket for static assets.    | [static-site](src/components/static-site/README.md)         |
-| `openTelemetry`         | namespace | ECS-side collector container generation.       | [otel](src/otel/README.md)                                  |
+| `OtelCollector`         | class     | ECS-side collector container generation.       | [otel](src/otel/README.md)                                  |
+| `OtelCollectorBuilder`  | class     | Fluent builder for OTel collector sidecars.    | [otel](src/otel/README.md)                                  |
 | `grafana`               | namespace | Grafana folders, data sources, and dashboards. | [grafana](src/components/grafana/README.md)                 |
 | `prometheus`            | namespace | PromQL query helpers for SLOs and latency.     | [prometheus](src/components/prometheus/README.md)           |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,8 @@ export { CloudFront } from './components/cloudfront';
 export { StaticSite } from './components/static-site';
 export { S3Assets } from './components/static-site/s3-assets';
 
-import { OtelCollectorBuilder } from './otel/builder';
-import { OtelCollector } from './otel';
-export const openTelemetry = { OtelCollector, OtelCollectorBuilder };
+export { OtelCollector } from './otel';
+export { OtelCollectorBuilder } from './otel/builder';
 
 export * as grafana from './components/grafana';
 export * as prometheus from './components/prometheus';

--- a/src/otel/README.md
+++ b/src/otel/README.md
@@ -1,6 +1,6 @@
 # `src/otel`
 
-The `openTelemetry` namespace provides package-standard OpenTelemetry collector sidecar helpers for ECS-based application components.
+The `OtelCollector` and `OtelCollectorBuilder` exports provide package-standard OpenTelemetry collector sidecar helpers for ECS-based application components.
 
 Use it to render collector configuration into ECS init/sidecar containers, shared config volume settings, OTLP ports, resource attributes, and task-role IAM policy fragments that components such as `WebServer` can attach to application tasks.
 
@@ -11,7 +11,7 @@ Use it to render collector configuration into ECS init/sidecar containers, share
 ```ts
 import * as studion from '@studion/infra-code-blocks';
 
-const collector = new studion.openTelemetry.OtelCollectorBuilder('app', 'dev')
+const collector = new studion.OtelCollectorBuilder('app', 'dev')
   .withOTLPReceiver(['http'])
   .withDebug('basic')
   .withTracesPipeline(['otlp'], [], ['debug'])
@@ -35,7 +35,7 @@ const logGroup = new aws.cloudwatch.LogGroup('otel-logs', {
 });
 const workspace = new aws.amp.Workspace('otel-amp', {});
 
-const collector = new studion.openTelemetry.OtelCollectorBuilder('api', env)
+const collector = new studion.OtelCollectorBuilder('api', env)
   .withDefault({
     prometheusNamespace: 'api',
     prometheusWorkspace: workspace,
@@ -83,20 +83,18 @@ export const webServerName = webServer.name;
 - `OtelCollectorBuilder.withDefault()` wires HTTP OTLP reception, a memory limiter, three named batch processors (`batch/metrics`, `batch/traces`, `batch/logs`), AMP remote write with SigV4 auth, AWS X-Ray export, CloudWatch Logs export, a health-check extension, metrics/traces/logs pipelines, and default telemetry settings.
 - `OtelCollectorBuilder` appends task-role IAM policies only when you call `withAPS()`, `withAWSXRayExporter()`, `withCloudWatchLogsExporter()`, or `withDefault()`; `withDebug()`, `withTelemetry()`, and extension methods only affect collector YAML.
 - The config builder validates that every receiver, processor, and exporter named in a pipeline has been defined, and that `memory_limiter` is not placed after another processor in any pipeline.
-- The source tree contains `OtelCollectorConfigBuilder` in `src/otel/config.ts`, and `OtelCollectorBuilder` relies on it internally to assemble and validate collector config. It is an internal implementation detail and is not exported through `@studion/infra-code-blocks`, so end consumers should treat `openTelemetry.OtelCollector`, `openTelemetry.OtelCollectorBuilder`, and `openTelemetry.OtelCollector.Config` as the supported public surface.
+- The source tree contains `OtelCollectorConfigBuilder` in `src/otel/config.ts`, and `OtelCollectorBuilder` relies on it internally to assemble and validate collector config. It is an internal implementation detail and is not exported through `@studion/infra-code-blocks`, so end consumers should treat `OtelCollector`, `OtelCollectorBuilder`, and `OtelCollector.Config` as the supported public surface.
 
 ## API Reference
 
-### `openTelemetry`
+### Exported Members
 
-**Exported Members**
+| Export                 | Kind  | Signature reference                                        |
+| ---------------------- | ----- | ---------------------------------------------------------- |
+| `OtelCollector`        | class | See [`OtelCollector`](#otelcollector) below.               |
+| `OtelCollectorBuilder` | class | See [`OtelCollectorBuilder`](#otelcollectorbuilder) below. |
 
-| Export                 | Kind  | Signature reference                                                                   |
-| ---------------------- | ----- | ------------------------------------------------------------------------------------- |
-| `OtelCollector`        | class | See [`openTelemetry.OtelCollector`](#opentelemetryotelcollector) below.               |
-| `OtelCollectorBuilder` | class | See [`openTelemetry.OtelCollectorBuilder`](#opentelemetryotelcollectorbuilder) below. |
-
-### `openTelemetry.OtelCollector`
+### `OtelCollector`
 
 **Signature**
 
@@ -432,7 +430,7 @@ type TelemetryConfig = {
 | `logs`<br/>`{ level: string }`    | Builder helpers constrain values to `'debug'`, `'warn'`, or `'error'`.      |
 | `metrics`<br/>`{ level: string }` | Builder helpers constrain values to `'basic'`, `'normal'`, or `'detailed'`. |
 
-### `openTelemetry.OtelCollectorBuilder`
+### `OtelCollectorBuilder`
 
 **Signature**
 

--- a/src/otel/README.md
+++ b/src/otel/README.md
@@ -1,6 +1,6 @@
 # `src/otel`
 
-The `OtelCollector` and `OtelCollectorBuilder` exports provide package-standard OpenTelemetry collector sidecar helpers for ECS-based application components.
+The `OtelCollector` and `OtelCollectorBuilder` implement the package-standard OpenTelemetry collector sidecar helpers for ECS-based application components.
 
 Use it to render collector configuration into ECS init/sidecar containers, shared config volume settings, OTLP ports, resource attributes, and task-role IAM policy fragments that components such as `WebServer` can attach to application tasks.
 
@@ -86,13 +86,6 @@ export const webServerName = webServer.name;
 - The source tree contains `OtelCollectorConfigBuilder` in `src/otel/config.ts`, and `OtelCollectorBuilder` relies on it internally to assemble and validate collector config. It is an internal implementation detail and is not exported through `@studion/infra-code-blocks`, so end consumers should treat `OtelCollector`, `OtelCollectorBuilder`, and `OtelCollector.Config` as the supported public surface.
 
 ## API Reference
-
-### Exported Members
-
-| Export                 | Kind  | Signature reference                                        |
-| ---------------------- | ----- | ---------------------------------------------------------- |
-| `OtelCollector`        | class | See [`OtelCollector`](#otelcollector) below.               |
-| `OtelCollectorBuilder` | class | See [`OtelCollectorBuilder`](#otelcollectorbuilder) below. |
 
 ### `OtelCollector`
 

--- a/tests/build/index.tst.ts
+++ b/tests/build/index.tst.ts
@@ -106,7 +106,7 @@ describe('Build output', () => {
 
       it('should have withOtelCollector method', () => {
         expect(builder.withOtelCollector).type.toBeCallableWith(
-          new studion.openTelemetry.OtelCollector('serviceName', 'testEnv', {
+          new studion.OtelCollector('serviceName', 'testEnv', {
             receivers: {},
             processors: {},
             exporters: {},
@@ -141,22 +141,16 @@ describe('Build output', () => {
   });
 
   describe('Open Telemetry', () => {
-    it('should export openTelemetry', () => {
-      expect(studion).type.toHaveProperty('openTelemetry');
-    });
-
     it('should contain OtelCollector', () => {
-      expect(studion.openTelemetry).type.toHaveProperty('OtelCollector');
+      expect(studion).type.toHaveProperty('OtelCollector');
     });
 
     it('should contain OtelCollectorBuilder', () => {
-      expect(studion.openTelemetry).type.toHaveProperty('OtelCollectorBuilder');
+      expect(studion).type.toHaveProperty('OtelCollectorBuilder');
     });
 
     describe('Instantiation', () => {
-      const {
-        openTelemetry: { OtelCollector, OtelCollectorBuilder },
-      } = studion;
+      const { OtelCollector, OtelCollectorBuilder } = studion;
 
       it('should construct OtelCollector', () => {
         expect(OtelCollector).type.toBeConstructableWith(
@@ -183,7 +177,7 @@ describe('Build output', () => {
     });
 
     describe('Builder', () => {
-      const builder = new studion.openTelemetry.OtelCollectorBuilder(
+      const builder = new studion.OtelCollectorBuilder(
         'serviceName',
         'testEnv',
       );

--- a/tests/grafana/infrastructure/index.ts
+++ b/tests/grafana/infrastructure/index.ts
@@ -33,10 +33,7 @@ const cloudWatchLogGroup = new aws.cloudwatch.LogGroup(
   { parent },
 );
 
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(
-  appName,
-  stackName,
-)
+const otelCollector = new studion.OtelCollectorBuilder(appName, stackName)
   .withDefault({
     prometheusNamespace: ampNamespace,
     prometheusWorkspace: ampWorkspace,

--- a/tests/otel/infrastructure/index.ts
+++ b/tests/otel/infrastructure/index.ts
@@ -34,10 +34,7 @@ const cloudWatchLogGroup = new aws.cloudwatch.LogGroup(
   { parent },
 );
 
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(
-  appName,
-  stackName,
-)
+const otelCollector = new studion.OtelCollectorBuilder(appName, stackName)
   .withDefault({
     prometheusNamespace,
     prometheusWorkspace,

--- a/tests/web-server/infrastructure/index.ts
+++ b/tests/web-server/infrastructure/index.ts
@@ -38,10 +38,7 @@ const sidecar = {
     startPeriod: 10,
   },
 };
-const otelCollector = new studion.openTelemetry.OtelCollectorBuilder(
-  webServerName,
-  stackName,
-)
+const otelCollector = new studion.OtelCollectorBuilder(webServerName, stackName)
   .withOTLPReceiver()
   .withDebug()
   .withMetricsPipeline(['otlp'], [], ['debug'])


### PR DESCRIPTION
This PR removes the `openTelemetry` wrapper object and exports `OtelCollector` and `OtelCollectorBuilder` as standard named exports, matching every other component in the library. Because `openTelemetry` was a runtime `const`, consumers could only reference its members as values rather than types, so annotations like `otelCollector: studion.openTelemetry.OtelCollector` failed with "refers to a value, but is being used as a type here." Direct named exports expose both the value and the type, so consumers can now write `studion.OtelCollector` in both positions.