### PR TITLE
fix: exclude test files from the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "release": "release-it --only-version",
     "test": "tsx --tsconfig tests/tsconfig.json tests/run.ts",
     "test:build": "npm run build && tstyche build",
+    "test:unit": "tsx --test src/**/*.test.ts",
     "prepare": "husky"
   },
   "prettier": "@studion/prettier-config",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.options.json",
   "files": [],
   "include": ["**/*"],
+  "exclude": ["**/*.test.ts"],
   "references": [],
   "compilerOptions": {
     "rootDir": ".",


### PR DESCRIPTION
The `*.test.ts` file are now explicitly excluded from the build. Previously the unit test were included in the build as they were placed alongside source files in at the `src`. Add the dedicated `test:unit` command to run unit tests and as ensure build-time validation on the test files.