### PR TITLE
fix: declare used `@smithy` packages as direct dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@aws-sdk/client-servicediscovery": "^3.1057.0",
         "@aws-sdk/client-ssm": "^3.1057.0",
         "@aws-sdk/client-xray": "^3.1057.0",
+        "@smithy/protocol-http": "^5.4.6",
+        "@smithy/signature-v4": "^5.4.6",
         "@studion/prettier-config": "^0.1.0",
         "@types/node": "^25",
         "http-status": "^2.1.0",
@@ -2974,13 +2976,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3041,14 +3043,28 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/signature-v4": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
-      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.6.tgz",
+      "integrity": "sha512-H6S7NyaaL+7qO8kIL7VQ7KyrGnKXdllGzJqvtp3hvDen25UOydKV51qGDVK0UciW125jV3CoLJQy/ihc0OEC6A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3056,9 +3072,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "@aws-sdk/client-servicediscovery": "^3.1057.0",
     "@aws-sdk/client-ssm": "^3.1057.0",
     "@aws-sdk/client-xray": "^3.1057.0",
+    "@smithy/protocol-http": "^5.4.6",
+    "@smithy/signature-v4": "^5.4.6",
     "@studion/prettier-config": "^0.1.0",
     "@types/node": "^25",
     "http-status": "^2.1.0",


### PR DESCRIPTION
Add `@smithy/protocol-http` and `@smithy/signature-v4` as explicit `devDependencies` since they are directly used in the `otel` test suite. 
Previously, these packages were consumed transitively without being declared. This caused test failures after an upstream dependency dropped `@smithy/protocol-http` from its own dependency tree, resulting in tests failing with an unresolvable import error.